### PR TITLE
Add 'New Project' menu to menu bar

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -17,6 +17,9 @@ menu.my_projects = My projects
 menu.community_projects = Community projects
 menu.profile = Profile
 menu.help = Help
+menu.newproject.title = New project
+menu.newproject.spin = Spin
+menu.newproject.c = Propeller C
 
 footer.licenselink = License
 footer.librarieslink = External libraries

--- a/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
@@ -27,10 +27,10 @@
                     <li><a href="<url:getUrl url="/my/projects.jsp"/>"><fmt:message key="menu.my_projects" /></a></li>
                     </shiro:authenticated>
                 <li>
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><fmt:message key="editor.projects.title" /> <b class="caret"></b></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><fmt:message key="menu.newproject.title" /> <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=SPIN"/>"><fmt:message key="editor.newproject.spin" /></a></li>
-                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=PROPC"/>"><fmt:message key="editor.newproject.c" /></a></li>
+                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=SPIN"/>"><fmt:message key="menu.newproject.spin" /></a></li>
+                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=PROPC"/>"><fmt:message key="menu.newproject.c" /></a></li>
                     </ul>
                 </li>
             </ul>

--- a/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
@@ -26,6 +26,13 @@
                     <shiro:authenticated>
                     <li><a href="<url:getUrl url="/my/projects.jsp"/>"><fmt:message key="menu.my_projects" /></a></li>
                     </shiro:authenticated>
+                <li>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><fmt:message key="editor.projects.title" /> <b class="caret"></b></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=SPIN"/>"><fmt:message key="editor.newproject.spin" /></a></li>
+                        <li><a href="<url:getUrl url="/projectcreate.jsp?lang=PROPC"/>"><fmt:message key="editor.newproject.c" /></a></li>
+                    </ul>
+                </li>
             </ul>
 
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
This PR adds the functionality to create a new project from a menu in the menubar. I believe this is necessary because the user should not always have to return to the BlocklyProp's homepage or go into an existing project to create a new project.

I will need to test this before it is merged into the master branch.

@PropGit What are your thoughts about this?