### PR TITLE
Another attempt to fix variable handling

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc.js
+++ b/src/main/webapp/cdn/blockly/generators/propc.js
@@ -167,24 +167,16 @@ Blockly.propc.init = function (workspace) {
         for (var x = 0; x < variables.length; x++) {
             var varName = Blockly.propc.variableDB_.getName(variables[x],
                     Blockly.Variables.NAME_TYPE);
-            /*  switch (typeof variables[x]) {
-             case 'number':
-             if (variables[x].indexOf(".") > -1) {
-             defvars[x] = "float " + varName + ';\n';
-             } else {
-             defvars[x] = "int " + varName + ';\n';
-             }
-             break
-             case 'string':
-             defvars[x] = "char " + varName + '[' + variables[x].length + '];\n';
-             break
-             case 'boolean':
-             defvars[x] = "boolean " + varName + ';\n';
-             break
-             default: */
-            defvars[x] = '' + '{{$var_type_' + varName /* variables[x].name */ + '}} ' +
-                    varName + '{{$var_length_' + varName /* variables[x].name */ + '}};\n';
-            //  }
+
+            if (variables[x].indexOf("\"") > -1) {
+              defvars[x] = "char " + varName + '{{$var_length_' + varName + '}};\n';
+            } else if (variables[x].indexOf(".") > -1) {
+              defvars[x] = "float " + varName + ';\n';
+            } else if (variables[x].indexOf("true") > -1 || variables[x].indexOf("false")) {
+              defvars[x] = "boolean " + varName + ';\n';
+            } else {
+              defvars[x] = "int " + varName + ';\n';
+            }
         }
         Blockly.propc.definitions_['variables'] = defvars.join('\n');
     }

--- a/src/main/webapp/cdn/blockly/generators/propc/variables.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/variables.js
@@ -128,26 +128,15 @@ Blockly.propc.variables_set = function () {
     var varName = Blockly.propc.variableDB_.getName(this.getFieldValue('VAR'),
             Blockly.Variables.NAME_TYPE);
     if (Blockly.propc.vartype_[varName] === undefined) {
-        Blockly.propc.vartype_[varName] = 'int';
-        /*
-         switch (typeof argument0) {
-         case 'number':
-         if (variables[x].indexOf(".") > -1) {
-         Blockly.propc.vartype_[varName] = 'float';
+         if (argument0.indexOf("\"") > -1) {
+           Blockly.propc.vartype_[varName] = 'char';
+         } else if (argument0.indexOf(".") > -1) {
+           Blockly.propc.vartype_[varName] = 'float';
+         } else if (argument0.indexOf("true") > -1 || argument0.indexOf("false")) {
+           Blockly.propc.vartype_[varName] = 'boolean';
          } else {
-         Blockly.propc.vartype_[varName] = 'int';
+           Blockly.propc.vartype_[varName] = 'int';
          }
-         break
-         case 'string':
-         Blockly.propc.vartype_[varName] = 'char';
-         break
-         case 'boolean':
-         Blockly.propc.vartype_[varName] = 'boolean';
-         break
-         default:
-         break
-         }
-         */
     }
     return varName + ' = ' + argument0 + ';\n';
 };


### PR DESCRIPTION
Ok here it goes...another try at fixing variable handling. Unlike my last attempt, this should not break BlocklyProp's ability to use variables.

This PR should allow you to now
1) Use all basic variable types (int, float, char, boolean)
2) Create char arrays (support for other arrays isn't in there yet)