### PR TITLE
Add global variables

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc.js
+++ b/src/main/webapp/cdn/blockly/generators/propc.js
@@ -153,6 +153,7 @@ Blockly.propc.init = function (workspace) {
     Blockly.propc.definitions_["include simpletools"] = '#include "simpletools.h"';
     // Create a dictionary of setups to be printed before the code.
     Blockly.propc.setups_ = {};
+    Blockly.propc.global_vars_ = {};
     // Create a list of stacks
     Blockly.propc.stacks_ = [];
     Blockly.propc.vartype_ = {};
@@ -203,6 +204,13 @@ Blockly.propc.finish = function (code) {
         } else {
             definitions.push(def);
         }
+    }
+
+    // Gives BlocklyProp developers the ability to add global variables
+    for (var name in Blockly.propc.global_vars_) {
+        var def = Blockly.propc.global_vars_[name];
+
+        definitions.push(def);
     }
 
     for (var def in definitions) {


### PR DESCRIPTION
Note: This requires #281 to be merged before this.

Small background change to give developers the ability to create global variables (with respect to scope) without using BlocklyProp's built-in variable handling. This is required for a number of blocks.