### PR TITLE
Set all variables default to int if they are used undeclared

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc.js
+++ b/src/main/webapp/cdn/blockly/generators/propc.js
@@ -211,6 +211,11 @@ Blockly.propc.finish = function (code) {
                 }
             }
         }
+
+        if (definitions[def].indexOf("{{$var_type_") > -1) {
+            definitions[def] = definitions[def].replace(/\{\{\$var_type_.*?\}\}/ig, "int").replace(/\{\{\$var_length_.*?\}\}/ig, '');
+        }
+
         definitions[def] = definitions[def].replace("\n\n", "\n");
     }
 


### PR DESCRIPTION
This fixes what Mr. Martin brought to my attention this afternoon. Unfortunately, I believe it will only be possible to default these variables to integer type.