### PR TITLE
Replace misspelled keywords 'integer' and 'boolean'

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/spin.js
+++ b/src/main/webapp/cdn/blockly/generators/spin.js
@@ -42,7 +42,7 @@ if (!Blockly.Spin.RESERVED_WORDS_) {
 
 Blockly.Spin.RESERVED_WORDS_ +=
         // http://arduino.cc/en/Reference/HomePage
-        'cogid,if,else,elseif,repeat,switch,case,while,do,break,continue,return,goto,define,include,HIGH,LOW,INPUT,OUTPUT,INPUT_PULLUP,true,false,interger, constants,floating,point,void,bookean,char,unsigned,byte,int,word,long,float,double,string,String,array,static, volatile,const,sizeof,pinMode,digitalWrite,digitalRead,analogReference,analogRead,analogWrite,tone,noTone,shiftOut,shitIn,pulseIn,millis,micros,delay,delayMicroseconds,min,max,abs,constrain,map,pow,sqrt,sin,cos,tan,randomSeed,random,lowByte,highByte,bitRead,bitWrite,bitSet,bitClear,bit,attachInterrupt,detachInterrupt,interrupts,noInterrupts'
+        'cogid,if,else,elseif,repeat,switch,case,while,do,break,continue,return,goto,define,include,HIGH,LOW,INPUT,OUTPUT,INPUT_PULLUP,true,false,integer,constants,floating,point,void,boolean,char,unsigned,byte,int,word,long,float,double,string,String,array,static, volatile,const,sizeof,pinMode,digitalWrite,digitalRead,analogReference,analogRead,analogWrite,tone,noTone,shiftOut,shitIn,pulseIn,millis,micros,delay,delayMicroseconds,min,max,abs,constrain,map,pow,sqrt,sin,cos,tan,randomSeed,random,lowByte,highByte,bitRead,bitWrite,bitSet,bitClear,bit,attachInterrupt,detachInterrupt,interrupts,noInterrupts'
         ;
 /**
  * Order of operation ENUMs.


### PR DESCRIPTION
The Spin reserved words for Integer and Boolean were misspelled. I did not see any errors related to this issue but went ahead and corrected the spelling.