### PR TITLE
Remove spurious ';\n' from output of rc_time component

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -170,7 +170,7 @@ Blockly.propc.rc_charge_discharge = function() {
     var pin = this.getFieldValue("PIN");
     var state = this.getFieldValue("STATE");
 
-    var code = 'rc_time(' + pin + ', ' + state + ');\n';
+    var code = 'rc_time(' + pin + ', ' + state + ')';
     return [code, Blockly.propc.ORDER_NONE];
 };
 


### PR DESCRIPTION
Correct compile error in issue #446, C, rc_time(), block