### PR TITLE
Correct implementation of formula to compute radius of rounded corners

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -462,7 +462,8 @@ Blockly.propc.oled_draw_rectangle = function() {
 
         code += point_x + ', ' + point_y + ', ';
         code += width + ', ' + height + ', ';
-        code += (width + height) / 20 + ', ';
+        code += ((Number(width) + Number(height)) / 20);
+//        code += '((' + width + ' + ' + height + ') / 20)' + ', ';
         code += 'oledc_color565('+ color_red + ', ' + color_green + ', ' + color_blue + ')';
     }
 


### PR DESCRIPTION
JavaScript was interpreting the 'width + height' as a string operation rather than a numeric operation.