### PR TITLE
Correct missing comma in function call

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -464,8 +464,7 @@ Blockly.propc.oled_draw_rectangle = function() {
 
         code += point_x + ', ' + point_y + ', ';
         code += width + ', ' + height + ', ';
-        code += ((Number(width) + Number(height)) / 20);
-//        code += '((' + width + ' + ' + height + ') / 20)' + ', ';
+        code += ((Number(width) + Number(height)) / 20) + ', ';
         code += 'oledc_color565('+ color_red + ', ' + color_green + ', ' + color_blue + ')';
     }
   


### PR DESCRIPTION
The existing code produces a function call that is missing a comma between the fifth and sixth parameters. This patch corrects that omission.