### PR TITLE
Update code to compute rectangle corner radius

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -464,7 +464,7 @@ Blockly.propc.oled_draw_rectangle = function() {
 
         code += point_x + ', ' + point_y + ', ';
         code += width + ', ' + height + ', ';
-        code += ((Number(width) + Number(height)) / 20) + ', ';
+        code += '((' + width + ') + (' + height + ') / 20),';
         code += 'oledc_color565('+ color_red + ', ' + color_green + ', ' + color_blue + ')';
     }
   


### PR DESCRIPTION
When the value block is replaced with a max_height or a max_width block, the replacement blocks return a string that is a function call into the OLED library. The current code is trying to convert this to a number and failing with a NaN error. 

The new code will simple pass the values returned from the value or max_* blocks and let the C compiler work out the math.
