### PR TITLE
Change new spin project to S3 Robot project in main page menu

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -19,7 +19,7 @@ menu.profile = Profile
 menu.public-profile = Public profile
 menu.help = Help
 menu.newproject.title = New project
-menu.newproject.spin = Spin
+menu.newproject.spin = S3 Robot
 menu.newproject.c = Propeller C
 
 footer.licenselink = License


### PR DESCRIPTION
I missed the main page "New Project" menu in my last PR, sorry.