### PR TITLE
Additional OLED blocks

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -288,6 +288,54 @@ Blockly.Blocks.oled_get_max_width = {
     }
 };
 
+Blockly.Blocks.oled_set_cursor = {
+    init: function() {
+        this.appendValueInput('X_POS')
+            .setCheck('Number')
+            .appendField("set cursor at (X, 0 to 95)");
+        this.appendValueInput('Y_POS')
+            .setCheck('Number')
+            .appendField("(Y, 0 to 63)");
+
+        this.setInputsInline(true);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(colorPalette.getColor('protocols'));
+    }
+};
+
+Blockly.Blocks.oled_print_text = {
+    init: function() {
+        this.appendValueInput('MESSAGE')
+            .setCheck('String')
+            .appendField("print text \"[ ]\"");
+ 
+        this.setInputsInline(true);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(colorPalette.getColor('protocols'));
+    }
+};
+
+Blockly.Blocks.oled_print_number = {
+    init: function() {
+        this.appendValueInput('NUMBER')
+            .setCheck('Number')
+            .appendField("print number [ ]");
+ 
+        this.setInputsInline(true);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(colorPalette.getColor('protocols'));
+    }
+};
+
+
+
+// set cursor - Position cursor at (x,y) where x=0 to 95 and y=0 to 63
+// draw text -  Print a string (up to 64 bytes)
+// draw number - Print a number (up to 64 digits) 
+
 Blockly.propc.oled_initialize = function () {
     var cs_pin = this.getFieldValue("CS");
     var dc_pin = this.getFieldValue("DC");
@@ -538,5 +586,25 @@ Blockly.propc.oled_get_max_width = function() {
 
     // Emit code to clear the screen
     var code = 'oledc_getWidth()';
+    return [code, Blockly.propc.ORDER_NONE];
+};
+
+Blockly.propc.oled_set_cursor = function() {
+    // Ensure header file is included
+    Blockly.propc.definitions_["oledtools"] = '#include "oledc.h"';
+
+    // Get user input
+    var x = Blockly.propc.valueToCode(this, 'X_POS', Blockly.propc.ORDER_NONE);
+    var y = Blockly.propc.valueToCode(this, 'Y_POS', Blockly.propc.ORDER_NONE);
+
+    // Do range checks
+    if (x < 0)  { x = 0; }
+    if (x > 95) { x = 95; }
+    if (y < 0)  { y = 0; }
+    if (y > 63) { y = 63; }
+    
+    var code = 'oledc_setCursor(' + x + ', ' + y + ',0);';
+//    code += this.getFieldValue('X_POS') + ', ';
+//    code += this.getFieldValue('Y_POS') + ', 0);';
     return [code, Blockly.propc.ORDER_NONE];
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -338,10 +338,6 @@ Blockly.Blocks.oled_print_number = {
 
 
 
-// set cursor - Position cursor at (x,y) where x=0 to 95 and y=0 to 63
-// draw text -  Print a string (up to 64 bytes)
-// draw number - Print a number (up to 64 digits) 
-
 Blockly.propc.oled_initialize = function () {
     var cs_pin = this.getFieldValue("CS");
     var dc_pin = this.getFieldValue("DC");

--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -604,7 +604,16 @@ Blockly.propc.oled_set_cursor = function() {
     if (y > 63) { y = 63; }
     
     var code = 'oledc_setCursor(' + x + ', ' + y + ',0);';
-//    code += this.getFieldValue('X_POS') + ', ';
-//    code += this.getFieldValue('Y_POS') + ', 0);';
-    return [code, Blockly.propc.ORDER_NONE];
+    return code;
+//    return [code, Blockly.propc.ORDER_NONE];
 };
+
+Blockly.propc.oled_print_text = function() {
+    // Ensure header file is included
+    Blockly.propc.definitions_["oledtools"] = '#include "oledc.h"';
+
+    var msg = Blockly.propc.valueToCode(this, 'MESSAGE', Blockly.propc.ORDER_NONE);
+    var code = 'oledc_drawText(' + msg + ');';
+    return code;
+};
+

--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -320,9 +320,15 @@ Blockly.Blocks.oled_print_text = {
 Blockly.Blocks.oled_print_number = {
     init: function() {
         this.appendValueInput('NUMBER')
-            .setCheck('Number')
-            .appendField("print number [ ]");
- 
+            .setCheck('String')
+            .appendField("print number [ ]")
+        this.appendDummyInput()
+            .appendField(new Blockly.FieldDropdown([
+                ["DEC", "DEC"],
+                ["BIN", "BIN"],
+                ["OCT", "OCT"],
+                ["HEX", "HEX"]
+            ]), "type");
         this.setInputsInline(true);
         this.setPreviousStatement(true, null);
         this.setNextStatement(true, null);
@@ -617,3 +623,12 @@ Blockly.propc.oled_print_text = function() {
     return code;
 };
 
+Blockly.propc.oled_print_number = function() {
+    // Ensure header file is included
+    Blockly.propc.definitions_["oledtools"] = '#include "oledc.h"';
+
+    var num = Blockly.propc.valueToCode(this, 'NUMBER', Blockly.propc.ORDER_NONE);
+    var type = this.getFieldValue('type');
+    var code = 'oledc_drawNumber(' + num + ', ' + type + ');';
+    return code;
+};

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -215,6 +215,26 @@
                     </value>
                 </block>
                 <block type="oled_text_size"></block>
+                <block type="oled_set_cursor">
+                    <value name="X_POS">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                    <value name="Y_POS">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                </block>
+                <block type="oled_print_text"></block>
+                <block type="oled_print_number">
+                    <value name="NUMBER">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                </block>
                 <block type="oled_draw_pixel">
                     <value name="X_AXIS">
                         <block type="math_number">

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -228,14 +228,7 @@
                     </value>
                 </block>
                 <block type="oled_print_text"></block>
-                <block type="oled_print_number">
-<%--                    <value name="NUMBER">
-                        <block type="string">
-                            <field name="NUM">0</field>
-                        </block>
-                    </value>
---%>
-                </block>
+                <block type="oled_print_number"></block>
                 <block type="oled_draw_pixel">
                     <value name="X_AXIS">
                         <block type="math_number">

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -229,11 +229,12 @@
                 </block>
                 <block type="oled_print_text"></block>
                 <block type="oled_print_number">
-                    <value name="NUMBER">
-                        <block type="math_number">
+<%--                    <value name="NUMBER">
+                        <block type="string">
                             <field name="NUM">0</field>
                         </block>
                     </value>
+--%>
                 </block>
                 <block type="oled_draw_pixel">
                     <value name="X_AXIS">


### PR DESCRIPTION
Reference issue #586, create new blocks for OLED to set cursor position, write a string and write a number formatted in decimal, hexadecimal, octal or binary