### PR TITLE
Correct print number to accept only numeric input

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -320,7 +320,7 @@ Blockly.Blocks.oled_print_text = {
 Blockly.Blocks.oled_print_number = {
     init: function() {
         this.appendValueInput('NUMBER')
-            .setCheck('String')
+            .setCheck('Number')
             .appendField("print number [ ]")
         this.appendDummyInput()
             .appendField(new Blockly.FieldDropdown([

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -228,7 +228,13 @@
                     </value>
                 </block>
                 <block type="oled_print_text"></block>
-                <block type="oled_print_number"></block>
+                <block type="oled_print_number">
+                    <value name="NUMBER">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                </block>
                 <block type="oled_draw_pixel">
                     <value name="X_AXIS">
                         <block type="math_number">


### PR DESCRIPTION
Reference issue #586. The print number function accepts a float value and not a string value. 