### PR TITLE
added Spin blicks for random number generation, uppdated other Spin blocks, added more reserved words for Spin

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/spin.js
+++ b/src/main/webapp/cdn/blockly/generators/spin.js
@@ -42,7 +42,7 @@ if (!Blockly.Spin.RESERVED_WORDS_) {
 
 Blockly.Spin.RESERVED_WORDS_ +=
         // http://arduino.cc/en/Reference/HomePage
-        'cogid,if,else,elseif,repeat,switch,case,while,do,break,continue,return,goto,define,include,HIGH,LOW,INPUT,OUTPUT,INPUT_PULLUP,true,false,integer,constants,floating,point,void,boolean,char,unsigned,byte,int,word,long,float,double,string,String,array,static, volatile,const,sizeof,pinMode,digitalWrite,digitalRead,analogReference,analogRead,analogWrite,tone,noTone,shiftOut,shitIn,pulseIn,millis,micros,delay,delayMicroseconds,min,max,abs,constrain,map,pow,sqrt,sin,cos,tan,randomSeed,random,lowByte,highByte,bitRead,bitWrite,bitSet,bitClear,bit,attachInterrupt,detachInterrupt,interrupts,noInterrupts'
+        'cogid,if,else,elseif,repeat,switch,case,while,do,break,continue,return,goto,define,include,HIGH,LOW,INPUT,OUTPUT,INPUT_PULLUP,true,false,integer,constants,floating,point,void,boolean,char,unsigned,byte,int,word,long,float,double,string,String,array,static, volatile,const,sizeof,pinMode,digitalWrite,digitalRead,analogReference,analogRead,analogWrite,tone,noTone,shiftOut,shitIn,pulseIn,millis,micros,delay,delayMicroseconds,min,max,abs,constrain,map,pow,sqrt,sin,cos,tan,randomSeed,random,lowByte,highByte,bitRead,bitWrite,bitSet,bitClear,bit,attachInterrupt,detachInterrupt,interrupts,noInterrupts,_clkfreq,_clkmode,_free,_stack,_xinfreq,abort,abs,absneg,add,addabs,adds,addsx,addx,and,andn,byte,bytefill,bytemove,call,case,chipver,clkfreq,clkmode,clkset,cmp,cmps,cmpsub,cmpsx,cmpx,cnt,cogid,coginit,cognew,cogstop,con,constant,if_nc_and_nz,min,pll4x,if_nc_and_z,mins,ctra,pll8x,ctrb,if_nc_or_nz,mov,pll16x,dat,if_nc_or_z,movd,posx,dira,if_ne,movi,pri,dirb,if_never,movs,pub,djnz,if_nz,mul,quit,else,if_nz_and_c,muls,rcfast,elseif,if_nz_and_nc,muxc,rcl,if_nz_or_c,elseifnot,muxnc,rcr,enc,if_nz_or_nc,muxnz,rcslow,false,if_z,muxz,rdbyte,file,if_z_and_c,neg,rdlong,fit,if_z_and_nc,negc,rdword,float,if_z_eq_c,negnc,reboot,from,if_z_ne_c,negnz,repeat,frqa,if_z_or_c,negx,res,frqb,if_z_or_nc,negz,result,hubop,ina,next,ret,if,inb,nop,return,ifnot,jmp,not,rev,if_a,jmpret,nr,rol,if_ae,lockclr,obj,ror,if_always,locknew,ones,round,if_b,lockret,or,sar,if_be,lockset,org,shl,if_c,long,other,shr,if_c_and_nz,longfill,outa,spr,if_c_and_z,longmove,outb,step,par,if_c_eq_z,lookdown,strcomp,if_c_ne_z,lookdownz,phsa,string,if_c_or_nz,lookup,phsb,strsize,if_c_or_z,lookupz,pi,sub,if_e,max,pll1x,subabs,pll2x,if_nc,maxs,subs,subsx,subx,sumc,sumnc,sumnz,sumz,test,testn,tjnz,tjz,to,true,trunc,until,var,vcfg,vscl,waitcnt,waitpeq,waitpne,waitvid,wc,while,word,wordfill,wordmove,wr,wrbyte,wrlong,wrword,wz,xinput,xor,xtal1,xtal2,xtal3'
         ;
 /**
  * Order of operation ENUMs.
@@ -75,10 +75,10 @@ var profile = {
         digital: [["0", "0"], ["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"], ["6", "6"], ["7", "7"], ["8", "8"], ["9", "9"], ["10", "10"], ["11", "11"], ["12", "12"], ["13", "13"], ["14", "14"], ["15", "15"], ["16", "16"], ["17", "17"], ["26", "26"], ["27", "27"]],
         servo: [["12", "12"], ["13", "13"], ["14", "14"], ["15", "15"], ["16", "16"]],
         analog: [["A0", "A0"], ["A1", "A1"], ["A2", "A2"], ["A3", "A3"], ["A4", "A4"], ["A5", "A5"]],
-        baudrate: 115200
+        baudrate: 9600
     },
     "s3": {
-        description: "Parallax propeller C3",
+        description: "Parallax propeller S3",
         digital: [["0", "0"], ["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"], ["6", "6"], ["7", "7"], ["8", "8"], ["9", "9"], ["10", "10"], ["11", "11"], ["12", "12"], ["13", "13"], ["14", "14"], ["15", "15"], ["16", "16"], ["17", "17"], ["18", "18"], ["19", "19"], ["20", "20"], ["21", "21"], ["22", "22"], ["23", "23"], ["24", "24"], ["25", "25"], ["26", "26"], ["27", "27"], ["28", "28"], ["29", "29"], ["30", "30"], ["31", "31"]],
         servo: [["0", "0"], ["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"], ["6", "6"], ["7", "7"], ["8", "8"], ["9", "9"], ["10", "10"], ["11", "11"], ["12", "12"], ["13", "13"], ["14", "14"], ["15", "15"], ["16", "16"], ["17", "17"], ["18", "18"], ["19", "19"], ["20", "20"], ["21", "21"], ["22", "22"], ["23", "23"], ["24", "24"], ["25", "25"], ["26", "26"], ["27", "27"], ["28", "28"], ["29", "29"], ["30", "30"], ["31", "31"]],
         analog: [["A0", "A0"], ["A1", "A1"], ["A2", "A2"], ["A3", "A3"], ["A4", "A4"], ["A5", "A5"]],

--- a/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
+++ b/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
@@ -152,13 +152,27 @@ Blockly.Blocks.scribbler_if_button = {
     }
 };
 
+Blockly.Blocks.scribbler_if_random = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField("if a virtual coin flip")
+            .appendField(new Blockly.FieldDropdown([['is', 'IS'], ['is not', 'IS_NOT'], ['was', 'WAS'], ['was not', 'WAS_NOT']]), 'RANDOM_CONDITION')
+            .appendField("heads")
+        this.appendStatementInput("IF_RANDOM")
+        this.setPreviousStatement(true);
+        this.setNextStatement(true);
+        this.setInputsInline(true);
+        this.setColour(colorPalette.getColor('input'));
+    }
+};
+
 Blockly.Blocks.scribbler_drive = {
     init: function () {
         this.appendDummyInput()
             .appendField("drive")
             .appendField(new Blockly.FieldDropdown([['forward', ''], ['backward', '-']]), 'DRIVE_DIRECTION')
             .appendField("and")
-            .appendField(new Blockly.FieldDropdown([['straight', 'STRAIGHT'], ['slightly to the right', 'SLIGHT_RIGHT'], ['gently to the right', 'GENTLE_RIGHT'], ['sharply to the right', 'SHARP_RIGHT'], ['slightly to the left', 'SLIGHT_LEFT'], ['gently to the left', 'GENTLE_LEFT'], ['sharply to the left', 'SHARP_LEFT']]), 'DRIVE_ANGLE')
+            .appendField(new Blockly.FieldDropdown([['sharply to the left', 'SHARP_LEFT'], ['gently to the left', 'GENTLE_LEFT'], ['slightly to the left', 'SLIGHT_LEFT'], ['straight', 'STRAIGHT'], ['slightly to the right', 'SLIGHT_RIGHT'], ['gently to the right', 'GENTLE_RIGHT'], ['sharply to the right', 'SHARP_RIGHT']]), 'DRIVE_ANGLE')
             .appendField("at")
             .appendField(new Blockly.FieldDropdown([['full', '255'], ['a quick', '191'], ['a gentle', '127'], ['a slow', '63']]), 'DRIVE_SPEED')
             .appendField("speed");
@@ -458,18 +472,85 @@ Blockly.Blocks.scribbler_servo = {
     }
 };
 
+Blockly.Blocks.scribbler_stop_servo = {
+    init: function () {
+        this.appendDummyInput("")
+                .appendField("disable servo on")
+                .appendField(new Blockly.FieldDropdown([['P0', '0'], ['P1', '1'], ['P2', '2'], ['P3', '3'], ['P4', '4'], ['P5', '5']]), "SERVO_PIN");
+	this.setInputsInline(false);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(colorPalette.getColor('io'));
+    }
+};
+
 Blockly.Blocks.scribbler_ping = {
     init: function () {
         this.appendDummyInput("")
                 .appendField("distance in")
                 .appendField(new Blockly.FieldDropdown([['inches (1 to 125)', '11848'], ['tenths of an inch (8 to 1,249)', '1185'], ['centimeters (4 to 635)', '2_332'], ['millimeters (39 to 6352)', '233']]), "PING_RANGE")
-                .appendField("from PING))) sensor on")
+                .appendField("from Ping))) sensor on")
                 .appendField(new Blockly.FieldDropdown([['P0', '0'], ['P1', '1'], ['P2', '2'], ['P3', '3'], ['P4', '4'], ['P5', '5']]), "PING_PIN");
 
 	this.setOutput(true, "Number");
         this.setColour(colorPalette.getColor('input'));
 	//this.setTooltip('Reads ambient light, in a range of 0 to 255');
         //this.setHelpUrl('help/block-scribbler.html#Light_Sensor');
+    }
+};
+
+Blockly.Blocks.spin_integer = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField(new Blockly.FieldTextInput('10', Blockly.FieldTextInput.numberValidator), 'INT_VALUE');
+
+        this.setOutput(true, 'Number');
+        this.setColour(colorPalette.getColor('math'));
+    }
+};
+
+Blockly.Blocks.scribbler_boolean = {
+    init: function () {
+        this.appendDummyInput("")
+                .appendField(new Blockly.FieldDropdown([['true', 'TRUE'], ['false', 'FALSE']]), 'BOOL');
+	this.setOutput(true, "Boolean");
+        this.setColour(colorPalette.getColor('math'));
+    }
+};
+
+Blockly.Blocks.scribbler_random_boolean = {
+    init: function () {
+        this.appendDummyInput("")
+                .appendField("random true/false");
+	this.setOutput(true, "Boolean");
+        this.setColour(colorPalette.getColor('math'));
+    }
+};
+
+Blockly.Blocks.scribbler_random_number = {
+    init: function () {
+        this.appendValueInput("LOW")
+                .setCheck("Number")
+		.setAlign(Blockly.ALIGN_RIGHT)
+                .appendField("random number from");
+        this.appendValueInput("HIGH")
+                .setCheck("Number")
+		.setAlign(Blockly.ALIGN_RIGHT)
+                .appendField("to");
+        this.setInputsInline(true);
+	this.setOutput(true, "Number");
+        this.setColour(colorPalette.getColor('math'));
+    }
+};
+
+Blockly.Blocks.spin_comment = {
+    init: function () {
+        this.appendDummyInput("")
+                .appendField("note:")
+                .appendField(new Blockly.FieldTextInput(""), "COMMENT");
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(colorPalette.getColor('programming'));
     }
 };
 
@@ -550,6 +631,16 @@ Blockly.Spin.scribbler_if_stalled = function () {
 
     var code = 'if Scribbler.SimpleStalled(Scribbler#' + this.getFieldValue('STALLED_CONDITION') + ')\n';
     return code + Blockly.Spin.statementToCode(this, 'IF_STALLED');
+};
+
+Blockly.Spin.scribbler_if_random = function () {
+    Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
+    if (Blockly.Spin.setups_[ 'setup_scribbler' ] === undefined) {
+        Blockly.Spin.setups_[ 'setup_scribbler' ] = 'Scribbler.Start';
+    }
+
+    var code = 'if Scribbler.SimpleRandom(Scribbler#' + this.getFieldValue('RANDOM_CONDITION') + ')\n';
+    return code + Blockly.Spin.statementToCode(this, 'IF_RANDOM');
 };
 
 Blockly.Spin.scribbler_if_button = function () {
@@ -788,6 +879,16 @@ Blockly.Spin.button_presses = function () {
     return [code, Blockly.Spin.ORDER_ATOMIC];
 };
 
+Blockly.Spin.scribbler_random_boolean = function () {
+    Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
+    if (Blockly.Spin.setups_[ 'setup_scribbler' ] === undefined) {
+        Blockly.Spin.setups_[ 'setup_scribbler' ] = 'Scribbler.Start';
+    }
+
+    var code = 'Scribbler.BooleanRandom';
+    return [code, Blockly.Spin.ORDER_ATOMIC];
+};
+
 Blockly.Spin.scribbler_ping = function () {
     Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
     if (Blockly.Spin.setups_[ 'setup_scribbler' ] === undefined) {
@@ -801,12 +902,54 @@ Blockly.Spin.scribbler_ping = function () {
 };
 
 Blockly.Spin.scribbler_servo = function () {
-    Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
-    if (Blockly.Spin.setups_[ 'setup_scribbler' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_scribbler' ] = 'Scribbler.Start';
+    if (Blockly.Spin.setups_[ 'setup_scribbler_servo' ] === undefined) {
+        Blockly.Spin.setups_[ 'setup_scribbler_servo' ] = 'ScribblerServo.Start';
     }
 
     var Angle = Blockly.Spin.valueToCode(this, 'SERVO_ANGLE', Blockly.Spin.ORDER_ATOMIC) || '0';
     var Pin = window.parseInt(this.getFieldValue('SERVO_PIN'));
     return 'Scribbler.Servo(' + Pin + ', ' + Angle + ')\n';
+};
+
+Blockly.Spin.scribbler_stop_servo = function () {
+    if (Blockly.Spin.setups_[ 'setup_scribbler_servo' ] === undefined) {
+        Blockly.Spin.setups_[ 'setup_scribbler_servo' ] = 'ScribblerServo.Start';
+    }
+
+    var Pin = window.parseInt(this.getFieldValue('SERVO_PIN'));
+    return 'Scribbler.ServoStop(' + Pin + ')\n';
+};
+
+Blockly.Spin.spin_integer = function () {
+    // Numeric value.
+    var code = window.parseInt(this.getFieldValue('INT_VALUE'));
+    // -4.abs() returns -4 in Dart due to strange order of operation choices.
+    // -4 is actually an operator and a number.  Reflect this in the order.
+    var order = code < 0 ?
+            Blockly.Spin.ORDER_UNARY_PREFIX : Blockly.Spin.ORDER_ATOMIC;
+    return [code, order];
+};
+
+Blockly.Spin.scribbler_boolean = function () {
+    // Boolean values true and false.
+    var code = this.getFieldValue('BOOL');
+    return [code, Blockly.Spin.ORDER_ATOMIC];
+};
+
+Blockly.Spin.scribbler_random_number = function () {
+    var low_number = Blockly.Spin.valueToCode(this, 'LOW', Blockly.Spin.ORDER_ATOMIC) || '0';
+    var high_number = Blockly.Spin.valueToCode(this, 'HIGH', Blockly.Spin.ORDER_ATOMIC) || '0';
+
+    Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
+    Blockly.Spin.serial_terminal_ = true;
+    if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+    }
+
+    var code = 'serial.RandomRange(' + low_number + ', ' + high_number + ')';
+    return [code, Blockly.Spin.ORDER_ATOMIC];
+};
+
+Blockly.Spin.spin_comment = function () {
+    return "' " + this.getFieldValue('COMMENT');
 };

--- a/src/main/webapp/cdn/blockly/generators/spin/serial.js
+++ b/src/main/webapp/cdn/blockly/generators/spin/serial.js
@@ -104,7 +104,7 @@ Blockly.Blocks.serial_send_ctrl = {
     init: function () {
         this.appendDummyInput()
                 .appendField("send control character")
-                .appendField(new Blockly.FieldDropdown([["Bell", "serial#BP"], ["Backspace", "serial#BS"], ["Tab", "serial#TB"], ["Line Feed", "serial#LF"], ["Carriage Return", "serial#NL"], ["Escape", "27"], ["Delete", "127"]]), "SERIAL_CHAR");
+                .appendField(new Blockly.FieldDropdown([["position cursor (x,y)", "Serial#PC"], ["backspace", "Serial#BS"], ["line feed", "Serial#LF"], ["carriage return", "Serial#NL"], ["position cursor (x)", "Serial#PX"], ["position cursor (y)", "Serial#PY"], ["clear screen", "Serial#CS"], ]), "SERIAL_CHAR");
         this.setInputsInline(false);
         this.setPreviousStatement(true, null);
         this.setNextStatement(true, null);
@@ -140,13 +140,13 @@ Blockly.Blocks.serial_cursor_xy = {
     helpUrl: '',
     init: function () {
         this.setColour(colorPalette.getColor('protocols'));
-        this.appendDummyInput("")
-                .appendField("set cursor position")
-                .appendField("X");
         this.appendValueInput("X")
-                .setCheck("Number");
+                .setCheck("Number")
+		.setAlign(Blockly.ALIGN_RIGHT)
+                .appendField("set cursor position  X");
         this.appendValueInput("Y")
                 .setCheck("Number")
+		.setAlign(Blockly.ALIGN_RIGHT)
                 .appendField("Y");
         this.setInputsInline(true);
         this.setPreviousStatement(true, null);
@@ -162,7 +162,7 @@ Blockly.Spin.serial_open = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     //  if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-    Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.StartRxTx( ' + dropdown_rx_pin + ', ' + dropdown_tx_pin + ', 0, ' + baud + ' )';
+    Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStartRxTx(' + dropdown_rx_pin + ', ' + dropdown_tx_pin + ', 0, ' + baud + ')';
     // }
 
     return '';
@@ -174,10 +174,10 @@ Blockly.Spin.serial_send_text = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return 'serial.Str(String("' + text + '"))\n';
+    return 'Scribbler.SerialStr(String("' + text + '"))\n';
 };
 
 Blockly.Spin.serial_send_char = function () {
@@ -185,10 +185,10 @@ Blockly.Spin.serial_send_char = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return 'serial.Char(' + dec_value + ')\n';
+    return 'Scribbler.SerialChar(' + dec_value + ')\n';
 };
 
 Blockly.Spin.serial_send_decimal = function () {
@@ -196,10 +196,10 @@ Blockly.Spin.serial_send_decimal = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return 'serial.Dec(' + dec_value + ')\n';
+    return 'Scribbler.SerialDec(' + dec_value + ')\n';
 };
 
 Blockly.Spin.serial_send_ctrl = function () {
@@ -207,10 +207,10 @@ Blockly.Spin.serial_send_ctrl = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return 'serial.Char(' + ctrl_char + ')\n';
+    return 'Scribbler.SerialChar(' + ctrl_char + ')\n';
 };
 
 Blockly.Spin.serial_rx_byte = function () {
@@ -218,20 +218,21 @@ Blockly.Spin.serial_rx_byte = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return ['serial.CharIn', Blockly.Spin.ORDER_ATOMIC];
+    var code = 'Scribbler.SerialCharIn'
+    return [code, Blockly.Spin.ORDER_ATOMIC];
 };
 
 Blockly.Spin.serial_clear = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart(' + profile["default"]["baudrate"] + ')';
     }
 
-    return 'serial.Clear\n';
+    return 'Scribbler.SerialClear\n';
 };
 
 Blockly.Spin.serial_cursor_xy = function () {
@@ -241,8 +242,8 @@ Blockly.Spin.serial_cursor_xy = function () {
     Blockly.Spin.definitions_[ "include_serial" ] = 'OBJserial    : "Parallax Serial Terminal"';
     Blockly.Spin.serial_terminal_ = true;
     if (Blockly.Spin.setups_[ 'setup_serial' ] === undefined) {
-        Blockly.Spin.setups_[ 'setup_serial' ] = 'serial.Start( ' + profile["default"]["baudrate"] + ' )';
+        Blockly.Spin.setups_[ 'setup_serial' ] = 'Scribbler.SerialStart( ' + profile["default"]["baudrate"] + ' )';
     }
 
-    return 'serial.PositionX(' + pos_x + ')\nserial.PositionY(' + pos_y + ')\n';
+    return 'Scribbler.SerialPositionX(' + pos_x + ')\nScribbler.SerialPositionY(' + pos_y + ')\n';
 };

--- a/src/main/webapp/cdn/blockly/language/common/math.js
+++ b/src/main/webapp/cdn/blockly/language/common/math.js
@@ -76,7 +76,7 @@ Blockly.Blocks['math_arithmetic'] = {
         var OPERATORS =
                 [["+", 'ADD'],
                     ["-", 'MINUS'],
-                    ["x", 'MULTIPLY'],
+                    ["\u00D7", 'MULTIPLY'],
                     ["/", 'DIVIDE']];
         this.setHelpUrl(Blockly.Msg.MATH_ARITHMETIC_HELPURL);
         this.setColour(colorPalette.getColor('math'));

--- a/src/main/webapp/frame/framespin.jsp
+++ b/src/main/webapp/frame/framespin.jsp
@@ -121,9 +121,12 @@
                 <block type="scribbler_if_obstacle"></block>
                 <block type="scribbler_if_light"></block>
                 <block type="scribbler_if_stalled"></block>
+                <block type="scribbler_if_random"></block>
             </category>
             <category name="Simple Actions" colour=185>
-                <block type="scribbler_drive"></block>
+                <block type="scribbler_drive">
+                    <field name="DRIVE_ANGLE">STRAIGHT</field>
+                </block>
                 <block type="scribbler_spin"></block>
                 <block type="scribbler_stop"></block>
                 <block type="scribbler_play">
@@ -148,12 +151,27 @@
                 </value>
                 <field name="TIMESCALE">1000</field>
             </block>
+            <block type="spin_comment"></block>
         </category>
         <category name="<fmt:message key="category.functions" />" custom="PROCEDURE" colour=225></category>
 	<category name="Variables" custom="VARIABLE" colour=250></category>
         <category name="Math" colour=275>
-            <block type="math_integer"></block>
-            <block type="logic_boolean"></block>
+            <block type="spin_integer"></block>
+            <block type="math_int_angle"></block>
+            <block type="scribbler_boolean"></block>
+            <block type="scribbler_random_boolean"></block>
+            <block type="scribbler_random_number">
+                <value name="LOW">
+                    <block type="math_integer">
+                        <field name="INT_VALUE">1</field>
+                    </block>
+                </value>
+                <value name="HIGH">
+                    <block type="math_integer">
+                        <field name="INT_VALUE">10</field>
+                    </block>
+                </value>
+            </block>
             <block type="math_arithmetic"></block>
             <block type="math_limit"></block>
             <block type="logic_operation"></block>
@@ -181,13 +199,15 @@
             <category name="Button" colour=140>
                 <block type="reset_button_presses"></block>
             </category>
-            <category name="Ping" colour=140>
+            <category name="Ping)))" colour=140>
                 <block type="scribbler_ping"></block>
             </category>
         </category>
         <category name="Actions" colour=185>
             <category name="Motors" colour=185>
-                <block type="scribbler_drive"></block>
+                <block type="scribbler_drive">
+                    <field name="DRIVE_ANGLE">STRAIGHT</field>
+                </block>
                 <block type="scribbler_spin"></block>
                 <block type="scribbler_stop"></block>
                 <block type="move_motors">
@@ -248,6 +268,7 @@
                         </block>
                     </value>
 		</block>
+                <block type="scribbler_stop_servo"></block>
             </category>
             <category name="Sound" colour=185>
                 <block type="scribbler_play">
@@ -287,7 +308,7 @@
                 <block type="serial_send_decimal"></block>
                 <block type="serial_send_char"></block>
                 <block type="serial_send_ctrl">
-                    <field name="SERIAL_CHAR">serial#NL</field>
+                    <field name="SERIAL_CHAR">Serial#NL</field>
                 </block>
                 <block type="serial_cursor_xy">
                     <value name="X">


### PR DESCRIPTION
- Added reserved words from Propeller Manual v1.2 appendix A
- Set Spin Propeller Activity Board WX baud rate to 9600, to work around Scribbler robot users possibly selecting it instead of the Scribbler robot
- Changed Scribbler 3 description from 'C3' to 'S3'
- Added Spin blocks for random numbers
- Reordered Scribbler drive block drop-down menu from straight.left,right to left,straight,right
- Added a stop servo block
- Changed product name styling from Ping and PING))) to Ping)))
- Separated Spin Boolean and integer constants from generic ones, and set colors to match the appropriate Spin menu color
- Added a Spin comment block
- Modified the servo blocks to automatically launch the Servo32 object
- Modified the serial and servo blocks to launch their respective objects from within Block_Wrapper.spin
- Modified the send control character block drop-down menu to use characters the BlocklyProp terminal is capable of displaying
- Modified the set cursor position block to support an external inputs layout
- Changed the math multiply symbol from an 'x' to a multiply symbol