### PR TITLE
Terminal Move to x,y block

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -115,22 +115,6 @@ Blockly.propc.base_freqout = function () {
     return code;
 };
 
-//Blockly.Blocks.string_block = {
-//    init: function () {
-//        this.setColour(colorPalette.getColor('programming'));
-//        this.appendDummyInput()
-//            .appendField(new Blockly.FieldTextInput('Hello'), "TEXT");
-//        this.setPreviousStatement(false, null);
-//        this.setNextStatement(false, null);
-//        this.setOutput(true, 'String');
-//    }
-//};
-
-//Blockly.propc.string_block = function() {
-//    var text = this.getFieldValue("TEXT");
-//    return [text];
-//};
-
 Blockly.Blocks.string_type_block = {
     init: function () {
         this.setColour(colorPalette.getColor('programming'));

--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -115,21 +115,21 @@ Blockly.propc.base_freqout = function () {
     return code;
 };
 
-Blockly.Blocks.string_block = {
-    init: function () {
-        this.setColour(colorPalette.getColor('programming'));
-        this.appendDummyInput()
-            .appendField(new Blockly.FieldTextInput('Hello'), "TEXT");
-        this.setPreviousStatement(false, null);
-        this.setNextStatement(false, null);
-        this.setOutput(true, 'String');
-    }
-};
+//Blockly.Blocks.string_block = {
+//    init: function () {
+//        this.setColour(colorPalette.getColor('programming'));
+//        this.appendDummyInput()
+//            .appendField(new Blockly.FieldTextInput('Hello'), "TEXT");
+//        this.setPreviousStatement(false, null);
+//        this.setNextStatement(false, null);
+//        this.setOutput(true, 'String');
+//    }
+//};
 
-Blockly.propc.string_block = function() {
-    var text = this.getFieldValue("TEXT");
-    return [text];
-};
+//Blockly.propc.string_block = function() {
+//    var text = this.getFieldValue("TEXT");
+//    return [text];
+//};
 
 Blockly.Blocks.string_type_block = {
     init: function () {

--- a/src/main/webapp/cdn/blockly/generators/propc/console.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/console.js
@@ -58,12 +58,11 @@ Blockly.Blocks.console_print_variables = {
     }
 };
 
-
+// Terminal print text
 Blockly.propc.console_print = function () {
     var text = Blockly.propc.valueToCode(this, 'MESSAGE', Blockly.propc.ORDER_ATOMIC);
     Blockly.propc.serial_terminal_ = true;
-
-    return 'print("' + text + '");';
+    return 'print(' + text + ');';
 };
 
 Blockly.propc.console_print_variables = function () {
@@ -135,6 +134,24 @@ Blockly.Blocks.console_move_to_row = {
     }
 };
 
+Blockly.Blocks.console_move_to_position = {
+    init: function () {
+        this.setColour(colorPalette.getColor('protocols'));
+        this.appendDummyInput()
+            .appendField("Terminal move to row");
+        this.appendValueInput('ROW')
+            .setCheck('Number');
+        this.appendDummyInput()
+            .appendField("column");
+        this.appendValueInput('COLUMN')
+            .setCheck('Number');
+
+        this.setInputsInline(true);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+    }
+};
+
 Blockly.propc.console_newline = function () {
     Blockly.propc.serial_terminal_ = true;
     return 'term_cmd(CR);';
@@ -145,22 +162,10 @@ Blockly.propc.console_clear = function () {
     return 'term_cmd(CLS);';
 };
 
-Blockly.propc.console_move_to_column = function () {
-    var column = Blockly.propc.valueToCode(this, 'COLUMNS', Blockly.propc.ORDER_NONE);
+Blockly.propc.console_move_to_position = function () {
     Blockly.propc.serial_terminal_ = true;
-
-    if (Number(column) < 0) {
-        column = 0;
-    } else if (Number(column) > 255) {
-        column = 255;
-    }
-
-    return 'term_cmd(CRSRX, ' + column + ');';
-};
-
-Blockly.propc.console_move_to_row = function () {
-    var row = Blockly.propc.valueToCode(this, 'ROWS', Blockly.propc.ORDER_NONE);
-    Blockly.propc.serial_terminal_ = true;
+    var row = Blockly.propc.valueToCode(this, 'ROW', Blockly.propc.ORDER_NONE);
+    var column = Blockly.propc.valueToCode(this, 'COLUMN', Blockly.propc.ORDER_NONE);
 
     if (Number(row) < 0) {
         row = 0;
@@ -168,5 +173,11 @@ Blockly.propc.console_move_to_row = function () {
         row = 255;
     }
 
-    return 'term_cmd(CRSRY, ' + row + ');';
+    if (Number(column) < 0) {
+        column = 0;
+    } else if (Number(column) > 255) {
+        column = 255;
+    }
+
+    return 'term_cmd(CRSRXY, ' + row + ', ' + column + ');';
 };

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -418,21 +418,6 @@
                         </block>
                     </value>
                 </block>
-<%--              
-                <block type="console_move_to_column">
-                    <value name="COLUMNS">
-                        <block type="math_number">
-                            <field name="NUM">0</field>
-                        </block>
-                    </value>
-                </block>
-                <block type="console_move_to_row">
-                    <value name="ROWS">
-                        <block type="math_number">
-                            <field name="NUM">0</field>
-                        </block>
-                    </value>
---%>
             </category>
             <category name="<fmt:message key="category.communicate.protocols" />">
                 <block type="serial_open"></block>

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -162,7 +162,6 @@
         <sep></sep>
         <category name="<fmt:message key="category.values" />" colour="220">
             <block type="math_number"></block>
-            <block type="string_block"></block>
             <block type="string_type_block"></block>
             <block type="logic_boolean"></block>
             <block type="high_low_value"></block>
@@ -395,7 +394,7 @@
             <category name="<fmt:message key="category.communicate.serial-terminal" />">
                 <block type="console_print">
                     <value name="MESSAGE">
-                        <block type="string_block"></block>
+                        <block type="string_type_block"></block>
                     </value>
                 </block>
                 <block type="console_print_variables">
@@ -407,6 +406,19 @@
                 </block>
                 <block type="console_newline"></block>
                 <block type="console_clear"></block>
+                <block type="console_move_to_position">
+                    <value name="ROW">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                    <value name="COLUMN">
+                        <block type="math_number">
+                            <field name="NUM">0</field>
+                        </block>
+                    </value>
+                </block>
+<%--              
                 <block type="console_move_to_column">
                     <value name="COLUMNS">
                         <block type="math_number">
@@ -420,7 +432,7 @@
                             <field name="NUM">0</field>
                         </block>
                     </value>
-                </block>
+--%>
             </category>
             <category name="<fmt:message key="category.communicate.protocols" />">
                 <block type="serial_open"></block>


### PR DESCRIPTION
Reference issue #666. Replace the Terminal move to x and move to y blocks with one block that uses x,y coordinates. 