### PR TITLE
Fixed errors in Terminal Print blocks

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/console.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/console.js
@@ -111,7 +111,7 @@ Blockly.propc.console_scan_number = function () {
     Blockly.propc.serial_terminal_ = true;
 
     if(data !== '') {
-        var code = 'scan("%d\n", &' + data + ');\n';
+        var code = 'scan("%d\\n", &' + data + ');\n';
 
         return code;
     } else {

--- a/src/main/webapp/cdn/blockly/generators/propc/console.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/console.js
@@ -127,7 +127,7 @@ Blockly.propc.console_print = function () {
     Blockly.propc.serial_terminal_ = true;
     
     var code = 'print(' + text + ');\n';
-    if (checkbox === 'TRUE') { code += 'print("\\n");\n'; }
+    if (checkbox === 'TRUE') { code += 'print("\\r");\n'; }
     return code;
 };
 
@@ -148,11 +148,11 @@ Blockly.propc.console_print_variables = function () {
         } 
     } else {
         if (format === 'BIN') {
-            code += '"%b\\n"';
+            code += '"%b\\r"';
         } else if (format === 'HEX') {
-            code += '"%x\\n"';                
+            code += '"%x\\r"';                
         } else {
-            code += '"%d\\n"';
+            code += '"%d\\r"';
         } 
     }
     code += ', ' + value + ');\n';


### PR DESCRIPTION
Fixed a missing escaped char, changed from \n to \r when "then a new line" box is checked for better compatibility with SimpleIDE.