### PR TITLE
Condensed EEPROM blocks (merge-fix for MatzElectronics)

### DIFF
--- a/src/main/webapp/cdn/blockly/language/common/pins.js
+++ b/src/main/webapp/cdn/blockly/language/common/pins.js
@@ -191,6 +191,7 @@ Blockly.Blocks.pulse_in = {
     }
 };
 
+// Code generator is located in base.js
 Blockly.Blocks.pulse_out = {
     init: function() {
         this.setColour(colorPalette.getColor('io'));


### PR DESCRIPTION
[ This is a PR with fixed merge conflict from MatzElectronics' #712 ]

Creates more condensed and safer EEPROM blocks - more detailed descriptions in the commits. Also re-hides i2c blocks - it may be some time before those get the attention they need to be used properly.