### PR TITLE
S3 Reset Block - Application Monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,30 @@
             <artifactId>metrics-core</artifactId>
             <version>${metrics-version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${metrics-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>${metrics-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-log4j</artifactId>
+            <version>${metrics-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-servlet</artifactId>
+            <version>${metrics-version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/com/parallax/server/blocklyprop/config/SetupConfig.java
+++ b/src/main/java/com/parallax/server/blocklyprop/config/SetupConfig.java
@@ -11,6 +11,7 @@ import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.parallax.server.blocklyprop.SessionData;
 import com.parallax.server.blocklyprop.jsp.Properties;
+import com.parallax.server.blocklyprop.monitoring.Monitor;
 import com.parallax.server.blocklyprop.utils.HelpFileInitializer;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -43,6 +44,7 @@ public class SetupConfig extends GuiceServletContextListener {
                 bind(Properties.class).asEagerSingleton();
 
                 bind(HelpFileInitializer.class).asEagerSingleton();
+                bind(Monitor.class).asEagerSingleton();
 
                 install(new PersistenceModule(configuration));
                 install(new DaoModule());

--- a/src/main/java/com/parallax/server/blocklyprop/monitoring/BlocklyPropInstrumentedFilterContextListener.java
+++ b/src/main/java/com/parallax/server/blocklyprop/monitoring/BlocklyPropInstrumentedFilterContextListener.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.parallax.server.blocklyprop.monitoring;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.servlet.InstrumentedFilterContextListener;
+
+/**
+ *
+ * @author Michel
+ */
+public class BlocklyPropInstrumentedFilterContextListener extends InstrumentedFilterContextListener {
+
+    @Override
+    protected MetricRegistry getMetricRegistry() {
+        return Monitor.metrics();
+    }
+
+}

--- a/src/main/java/com/parallax/server/blocklyprop/monitoring/Monitor.java
+++ b/src/main/java/com/parallax/server/blocklyprop/monitoring/Monitor.java
@@ -1,0 +1,83 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.parallax.server.blocklyprop.monitoring;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.PickledGraphite;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.log4j.InstrumentedAppender;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.configuration.Configuration;
+import org.apache.log4j.LogManager;
+
+/**
+ *
+ * @author Michel
+ */
+@Singleton
+public class Monitor {
+
+    private static final MetricRegistry metrics = new MetricRegistry();
+
+    private final boolean consoleEnabled;
+    private final int consoleReportingInterval;
+
+    private final boolean graphiteEnabled;
+    private final String graphitePrefix;
+    private final String graphiteServerAddress;
+    private final int graphiteServerPort;
+    private final int graphiteReportingInterval;
+
+    @Inject
+    public Monitor(Configuration configuration) {
+        consoleEnabled = configuration.getBoolean("monitor.console.enabled", false);
+        consoleReportingInterval = configuration.getInt("monitor.console.interval", 300);
+
+        graphiteEnabled = configuration.getBoolean("monitor.graphite.enabled", false);
+        graphitePrefix = configuration.getString("monitor.graphite.prefix", "blocklyprop");
+        graphiteServerAddress = configuration.getString("monitor.graphite.address", "localhost");
+        graphiteServerPort = configuration.getInt("monitor.graphite.port", 2003);
+        graphiteReportingInterval = configuration.getInt("monitor.graphite.interval", 30);
+
+        init();
+    }
+    
+    private void init() {
+        if (consoleEnabled) {
+            ConsoleReporter reporter = ConsoleReporter.forRegistry(metrics).convertDurationsTo(TimeUnit.MILLISECONDS).build();
+            reporter.start(consoleReportingInterval, TimeUnit.SECONDS);
+        }
+
+        if (graphiteEnabled) {
+            final PickledGraphite pickledGraphite = new PickledGraphite(new InetSocketAddress(graphiteServerAddress, graphiteServerPort));
+            final GraphiteReporter graphiteReporter = GraphiteReporter.forRegistry(metrics).prefixedWith(graphitePrefix).convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL).build(pickledGraphite);
+            graphiteReporter.start(graphiteReportingInterval, TimeUnit.SECONDS);
+        }
+
+        InstrumentedAppender appender = new InstrumentedAppender(metrics);
+        appender.activateOptions();
+
+        LogManager.getRootLogger().addAppender(appender);
+
+        MemoryUsageGaugeSet memoryUsageGaugeSet = new MemoryUsageGaugeSet();
+        metrics.registerAll(memoryUsageGaugeSet);
+
+        GarbageCollectorMetricSet garbageCollectorMetricSet = new GarbageCollectorMetricSet();
+        metrics.registerAll(garbageCollectorMetricSet);
+    }
+
+    public static MetricRegistry metrics() {
+        return metrics;
+    }
+
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,6 +64,21 @@
         <url-pattern>/apidoc</url-pattern>
     </servlet-mapping>
 
+    <!-- Monitor -->
+    <listener>
+        <description>Add Metrics to context</description>
+        <listener-class>com.parallax.server.blocklyprop.monitoring.BlocklyPropInstrumentedFilterContextListener</listener-class>
+    </listener>
+
+    <filter>
+        <filter-name>instrumentedFilter</filter-name>
+        <filter-class>com.codahale.metrics.servlet.InstrumentedFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>instrumentedFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <!-- Other servlets -->
 
     <welcome-file-list>

--- a/src/main/webapp/cdn/blockly/generators/propc/oled.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/oled.js
@@ -97,7 +97,7 @@ Blockly.Blocks.oled_draw_circle = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(colorPalette.getColor('protocols'));
-    this.setTooltip('Set coordinates to draw a circle');
+    this.setTooltip('<b>Set</b> coordinates to draw a circle');
   }
 };
 

--- a/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
+++ b/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
@@ -958,7 +958,6 @@ Blockly.Spin.factory_reset = function () {
     Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
 
     var code = 'scribbler.RestoreS3Demo';
-    return code;
-//    return [code, Blockly.Spin.ORDER_ATOMIC];
+    return [code, Blockly.Spin.ORDER_ATOMIC];
     
 };

--- a/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
+++ b/src/main/webapp/cdn/blockly/generators/spin/scribbler.js
@@ -554,6 +554,14 @@ Blockly.Blocks.spin_comment = {
     }
 };
 
+Blockly.Blocks.factory_reset = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField("restore_s3_demo");
+        this.setColour(colorPalette.getColor('programming'));
+    }
+};
+
 //==============================================================================
 
 
@@ -944,4 +952,13 @@ Blockly.Spin.scribbler_random_number = function () {
 
 Blockly.Spin.spin_comment = function () {
     return "' " + this.getFieldValue('COMMENT') + '\n';
+};
+
+Blockly.Spin.factory_reset = function () {
+    Blockly.Spin.definitions_[ "include_scribbler" ] = 'OBJscribbler    : "Block_Wrapper"';
+
+    var code = 'scribbler.RestoreS3Demo';
+    return code;
+//    return [code, Blockly.Spin.ORDER_ATOMIC];
+    
 };

--- a/src/main/webapp/frame/framespin.jsp
+++ b/src/main/webapp/frame/framespin.jsp
@@ -324,6 +324,9 @@
                 </block>
                 <block type="serial_rx_byte"></block>
             </category>
+            <category name="Reset" colour=185>
+                <block type="factory_reset"></block>
+            </category>
         </category>
     </xml>
 </body>


### PR DESCRIPTION
This update adds a S3 reset block to the Spin block family. The block reloads the S3 with the default demo program.

An application monitor is also included in this PR. It will allow us to monitor the app in real time to a console and/or to a Graphics server.

[Note that this change also requires an update to the blocklyprop.properties file.]
