### PR TITLE
Add a missing forward-slash to a file URL

### DIFF
--- a/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
@@ -26,7 +26,7 @@
                     <!-- Windows 32bit client -->
                     <div class="client Windows">
                         <img src="<url:getCdnUrl url="/images/os-icons/windows.png"/>"/>
-                        <a href="${properties:downloadfiles('BlocklyPropClient-setup-32.exe')}">
+                        <a href="${properties:downloadfiles('/BlocklyPropClient-setup-32.exe')}">
                             <fmt:message key="clientdownload.client.windows32.installer" /></a>
                     </div>
                     <div class="client Windows">


### PR DESCRIPTION
A missing '/' results in a 404 error. Corrected.