### PR TITLE
Add string blocks

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -33,9 +33,10 @@ html.content_missing = Content missing
 
 clientdownload.title = BlocklyProp-client
 clientdownload.showall = Show clients for all operating systems
+clientdownload.client.macos = MacOS client zip
 clientdownload.client.macos.installer = MacOS client installer
-clientdownload.client.windows32.installer = Windows 7/8/8.1/10 (32-bit) client installer
-clientdownload.client.windows64.installer = Windows 7/8/8.1/10 (64-bit) client installer
+clientdownload.client.windows64 = Windows 64-bit client zip
+clientdownload.client.windows64.installer = Windows 64-bit client installer
 
 help.title = Help
 help.not-found = Help file not found
@@ -228,6 +229,8 @@ editor.demo.dialog.login.registerlink = If you don't yet have an account, regist
 
 category.control = Control
 category.operators = Operators
+category.operators.numbers = Numbers
+category.operators.strings = Strings
 category.values = Values
 category.input-output = Input/Output
 category.input-output.pin-states = Pin states

--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -33,10 +33,9 @@ html.content_missing = Content missing
 
 clientdownload.title = BlocklyProp-client
 clientdownload.showall = Show clients for all operating systems
-clientdownload.client.macos = MacOS client zip
 clientdownload.client.macos.installer = MacOS client installer
-clientdownload.client.windows64 = Windows 64-bit client zip
-clientdownload.client.windows64.installer = Windows 64-bit client installer
+clientdownload.client.windows32.installer = Windows 7/8/8.1/10 (32-bit) client installer
+clientdownload.client.windows64.installer = Windows 7/8/8.1/10 (64-bit) client installer
 
 help.title = Help
 help.not-found = Help file not found

--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -134,6 +134,119 @@ Blockly.propc.string_type_block = function() {
     return [code, Blockly.propc.ORDER_NONE];
 };
 
+Blockly.Blocks.char_type_block = {
+    init: function () {
+        this.setColour(colorPalette.getColor('programming'));
+        this.appendDummyInput()
+                .appendField("character")
+                .appendField(new Blockly.FieldDropdown([
+                    ["32 - space", "32"],
+                    ["33 - !", "33"],
+                    ["34 - \"", "34"],
+                    ["35 - #", "35"],
+                    ["36 - $", "36"],
+                    ["37 - %", "37"],
+                    ["38 - &", "38"],
+                    ["39 - '", "39"],
+                    ["40 - (", "40"],
+                    ["41 - )", "41"],
+                    ["42 - *", "42"],
+                    ["43 - +", "43"],
+                    ["44 - ,", "44"],
+                    ["45 - -", "45"],
+                    ["46 - .", "46"],
+                    ["47 - /", "47"],
+                    ["48 - 0", "48"],
+                    ["49 - 1", "49"],
+                    ["50 - 2", "50"],
+                    ["51 - 3", "51"],
+                    ["52 - 4", "52"],
+                    ["53 - 5", "53"],
+                    ["54 - 6", "54"],
+                    ["55 - 7", "55"],
+                    ["56 - 8", "56"],
+                    ["57 - 9", "57"],
+                    ["58 - :", "58"],
+                    ["59 - ;", "59"],
+                    ["60 - <", "60"],
+                    ["61 - =", "61"],
+                    ["62 - >", "62"],
+                    ["63 - ?", "63"],
+                    ["64 - @", "64"],
+                    ["65 - A", "65"],
+                    ["66 - B", "66"],
+                    ["67 - C", "67"],
+                    ["68 - D", "68"],
+                    ["69 - E", "69"],
+                    ["70 - F", "70"],
+                    ["71 - G", "71"],
+                    ["72 - H", "72"],
+                    ["73 - I", "73"],
+                    ["74 - J", "74"],
+                    ["75 - K", "75"],
+                    ["76 - L", "76"],
+                    ["77 - M", "77"],
+                    ["78 - N", "78"],
+                    ["79 - O", "79"],
+                    ["80 - P", "80"],
+                    ["81 - Q", "81"],
+                    ["82 - R", "82"],
+                    ["83 - S", "83"],
+                    ["84 - T", "84"],
+                    ["85 - U", "85"],
+                    ["86 - V", "86"],
+                    ["87 - W", "87"],
+                    ["88 - X", "88"],
+                    ["89 - Y", "89"],
+                    ["90 - Z", "90"],
+                    ["91 - [", "91"],
+                    ["92 - \\", "92"],
+                    ["93 - ]", "93"],
+                    ["94 - ^", "94"],
+                    ["95 - _", "95"],
+                    ["96 - `", "96"],
+                    ["97 - a", "97"],
+                    ["98 - b", "98"],
+                    ["99 - c", "99"],
+                    ["100 - d", "100"],
+                    ["101 - e", "101"],
+                    ["102 - f", "102"],
+                    ["103 - g", "103"],
+                    ["104 - h", "104"],
+                    ["105 - i", "105"],
+                    ["106 - j", "106"],
+                    ["107 - k", "107"],
+                    ["108 - l", "108"],
+                    ["109 - m", "109"],
+                    ["110 - n", "110"],
+                    ["111 - o", "111"],
+                    ["112 - p", "112"],
+                    ["113 - q", "113"],
+                    ["114 - r", "114"],
+                    ["115 - s", "115"],
+                    ["116 - t", "116"],
+                    ["117 - u", "117"],
+                    ["118 - v", "118"],
+                    ["119 - w", "119"],
+                    ["120 - x", "120"],
+                    ["121 - y", "121"],
+                    ["122 - z", "122"],
+                    ["123 - {", "123"],
+                    ["124 - |", "124"],
+                    ["125 - }", "125"],
+                    ["126 - ~", "126"]]), "CHAR");
+        this.setPreviousStatement(false, null);
+        this.setNextStatement(false, null);
+        this.setOutput(true, 'Number');
+    }
+};
+
+Blockly.propc.char_type_block = function() {
+    var code = this.getFieldValue("CHAR");
+
+    return [code, Blockly.propc.ORDER_NONE];
+};
+
 Blockly.Blocks.system_counter = {
   init: function() {
         this.setColour(colorPalette.getColor('programming'));
@@ -151,10 +264,10 @@ Blockly.propc.system_counter = function() {
 
 Blockly.Blocks.string_length = {
     init: function () {
-        this.setColour(colorPalette.getColor('programming'));
+        this.setColour(colorPalette.getColor('math'));
         this.appendValueInput('VALUE')
                 .setCheck('String')
-                .appendField("length of text");
+                .appendField("length of string");
         this.setInputsInline(true);
         this.setOutput(true, 'Number');
         this.setPreviousStatement(false, null);

--- a/src/main/webapp/cdn/blockly/generators/propc/console.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/console.js
@@ -54,7 +54,8 @@ Blockly.Blocks.console_print_variables = {
             .appendField(new Blockly.FieldDropdown([
                 ['Decimal','DEC'],
                 ['Hexadecimal','HEX'],
-                ['Binary', 'BIN']
+                ['Binary', 'BIN'],
+                ['ASCII Character', 'CHAR']
             ]), "FORMAT");
         this.appendDummyInput()
             .appendField("then a new line")
@@ -166,19 +167,27 @@ Blockly.propc.console_print_variables = function () {
             code += '"%b"';
         } else if (format === 'HEX') {
             code += '"%x"';                
-        } else {
+        } else if (format === 'DEC') {
             code += '"%d"';
-        } 
+        } else {
+            code += '"%c"';
+        }
     } else {
         if (format === 'BIN') {
             code += '"%b\\r"';
         } else if (format === 'HEX') {
             code += '"%x\\r"';                
+        } else if (format === 'DEC') {
+            code += '"%d"';
         } else {
-            code += '"%d\\r"';
-        } 
+            code += '"%c"';
+        }
     }
-    code += ', ' + value + ');\n';
+    if (format === 'CHAR') {
+        code += ', (' + value + ' & 0xFF));\n';
+    } else {
+        code += ', ' + value + ');\n';        
+    }
     return code;
 };
 

--- a/src/main/webapp/cdn/blockly/generators/propc/console.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/console.js
@@ -178,9 +178,9 @@ Blockly.propc.console_print_variables = function () {
         } else if (format === 'HEX') {
             code += '"%x\\r"';                
         } else if (format === 'DEC') {
-            code += '"%d"';
+            code += '"%d\\r"';
         } else {
-            code += '"%c"';
+            code += '"%c\\r"';
         }
     }
     if (format === 'CHAR') {

--- a/src/main/webapp/cdn/blockly/language/common/logic.js
+++ b/src/main/webapp/cdn/blockly/language/common/logic.js
@@ -30,9 +30,11 @@ Blockly.Blocks.logic_compare = {
     init: function () {
         this.setColour(colorPalette.getColor('math'));
         this.setOutput(true, 'Boolean');
-        this.appendValueInput('A');
+        this.appendValueInput('A')
+            .setCheck("Number");
         this.appendValueInput('B')
-                .appendField(new Blockly.FieldDropdown(this.OPERATORS), 'OP');
+            .setCheck("Number")
+            .appendField(new Blockly.FieldDropdown(this.OPERATORS), 'OP');
         this.setInputsInline(true);
         // Assign 'this' to a variable for use in the tooltip closure below.
         var thisBlock = this;
@@ -135,4 +137,227 @@ Blockly.Blocks.logic_null = {
                 .appendField(Blockly.LANG_LOGIC_NULL);
         this.setTooltip(Blockly.LANG_LOGIC_NULL_TOOLTIP);
     }
+};
+
+Blockly.Blocks.combine_strings = {
+    init: function() {
+        this.setColour(colorPalette.getColor('math'));
+        this.appendValueInput("STRA")
+            .setCheck("String")
+            .appendField("combine string");
+        this.appendValueInput("STRB")
+            .setCheck("String")
+            .appendField("with string");
+        this.appendDummyInput()
+            .appendField("store in")
+            .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'VALUE');
+        this.setInputsInline(true);
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+    },
+    
+    getVars: function () {
+        return [this.getFieldValue('VALUE')];
+    },
+    
+    renameVar: function (oldName, newName) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
+            this.setTitleValue(newName, 'VALUE');
+        }
+    }
+};
+
+Blockly.propc.combine_strings = function () {
+    var strA = Blockly.propc.valueToCode(this, 'STRA', Blockly.propc.ORDER_ATOMIC) || '';
+    var strB = Blockly.propc.valueToCode(this, 'STRB', Blockly.propc.ORDER_ATOMIC) || '';
+    var data = Blockly.propc.variableDB_.getName(this.getFieldValue('VALUE'), Blockly.Variables.NAME_TYPE);
+    var code = '';
+
+    Blockly.propc.vartype_[data] = 'char *';
+
+    if(strA !== '' && strB !== '') {
+        Blockly.propc.definitions_['str_Buffer'] = 'char *__scBfr;';
+
+        code += 'sprint(__scBfr, "%s%s", ' + strA + ', ' + strB + ');\n'; 
+        code += 'strcpy(' + data + ', __scBfr);\n'; 
+    } else if(strA !== ''){           
+         code += 'strcpy(' + data + ', ' + strB + ');\n'; 
+    } else if(strB !== ''){           
+         code += 'strcpy(' + data + ', ' + strA + ');\n'; 
+    } else {            
+        code += '// Both of the strings to combine are blank!\n';
+    }
+    return code;
+};
+
+Blockly.Blocks.find_substring = {
+    init: function() {
+        this.setColour(colorPalette.getColor('math'));
+        this.appendValueInput("SUBSTR")
+            .setCheck("String")
+            .appendField("find location of text");
+        this.appendValueInput("STR")
+            .setCheck("String")
+            .appendField("in string");
+        this.setInputsInline(true);
+        this.setOutput(true, "Number");
+  }
+};
+
+Blockly.propc.find_substring = function () {
+    var subs = Blockly.propc.valueToCode(this, 'SUBSTR', Blockly.propc.ORDER_ATOMIC) || '';
+    var strs = Blockly.propc.valueToCode(this, 'STR', Blockly.propc.ORDER_ATOMIC) || '';
+
+    Blockly.propc.definitions_['find_sub'] = 'int find_sub(char *__strS, char *__subS) { char* __pos = strstr(__strS, __subS); return (__pos - __strS + 1); }\n';
+    
+    var code = '';
+
+    if(subs !== '' && strs !== '') {
+        code += 'find_sub(' + strs + ', ' + subs + ')'; 
+    } else {           
+        code += '0'; 
+    }
+    
+    return [code, Blockly.propc.ORDER_NONE];
+};
+
+Blockly.Blocks.get_char_at_position = {
+  init: function() {
+    this.setColour(colorPalette.getColor('math'));
+    this.appendValueInput("POSITION")
+        .setCheck("Number")
+        .appendField("get character at position");
+    this.appendDummyInput()
+        .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'VALUE');
+    this.setInputsInline(true);
+    this.setOutput(true, "Number");
+    },
+    
+    getVars: function () {
+        return [this.getFieldValue('VALUE')];
+    },
+    
+    renameVar: function (oldName, newName) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
+            this.setTitleValue(newName, 'VALUE');
+        }
+    }
+};
+
+Blockly.propc.get_char_at_position = function () {
+    var pos = Blockly.propc.valueToCode(this, 'POSITION', Blockly.propc.ORDER_ATOMIC) || '1';
+    var data = Blockly.propc.variableDB_.getName(this.getFieldValue('VALUE'), Blockly.Variables.NAME_TYPE);
+
+    var code = '0';
+    
+    if(Blockly.propc.vartype_[data] === 'char *') 
+    {
+        code = data + '[(' + pos + '>strlen(' + data + ')?strlen(' + data + '):' + pos + ')-1]';
+    }
+    
+    return [code, Blockly.propc.ORDER_NONE];
+};
+
+Blockly.Blocks.set_char_at_position = {
+  init: function() {
+    this.setColour(colorPalette.getColor('math'));
+    this.appendValueInput("POSITION")
+        .setCheck("Number")
+        .appendField("set character at position");
+    this.appendDummyInput()
+        .appendField("of string")
+        .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'VALUE');
+    this.appendValueInput("CHAR")
+        .setCheck("Number")
+        .appendField("to");
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+  }
+};
+
+Blockly.propc.set_char_at_position = function () {
+    var pos = Blockly.propc.valueToCode(this, 'POSITION', Blockly.propc.ORDER_ATOMIC) || '1';
+    var chr = Blockly.propc.valueToCode(this, 'CHAR', Blockly.propc.ORDER_ATOMIC) || '32';
+    var data = Blockly.propc.variableDB_.getName(this.getFieldValue('VALUE'), Blockly.Variables.NAME_TYPE);
+
+    return data + '[(' + pos + '>strlen(' + data + ')?strlen(' + data + '):' + pos + ')-1] = (' + chr + ' & 0xFF)\n;';
+};
+
+Blockly.Blocks.get_substring = {
+  init: function() {
+    this.setColour(colorPalette.getColor('math'));
+    this.appendDummyInput()
+        .appendField("get part of string")
+        .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'FROM_STR');
+    this.appendValueInput("START")
+        .setCheck("Number")
+        .appendField("from position");
+    this.appendValueInput("END")
+        .setCheck("Number")
+        .appendField("to position");
+    this.appendDummyInput()
+        .appendField("store in")
+        .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'TO_STR');
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+  }
+};
+
+Blockly.propc.get_substring = function () {
+    var sst = Blockly.propc.valueToCode(this, 'START', Blockly.propc.ORDER_ATOMIC) || '1';
+    var snd = Blockly.propc.valueToCode(this, 'END', Blockly.propc.ORDER_ATOMIC) || '2';
+    var frStr = Blockly.propc.variableDB_.getName(this.getFieldValue('FROM_STR'), Blockly.Variables.NAME_TYPE);
+    var toStr = Blockly.propc.variableDB_.getName(this.getFieldValue('TO_STR'), Blockly.Variables.NAME_TYPE);
+
+    Blockly.propc.vartype_[toStr] = 'char *';
+    Blockly.propc.definitions_['str_Buffer'] = 'char *__scBfr;';
+
+    var code = '';
+    
+    if(Blockly.propc.vartype_[frStr] === 'char *') 
+    {
+        Blockly.propc.definitions_['__ssIdx'] = 'int __ssIdx, __stIdx;';
+
+        code += '__stIdx = 0;\nfor(__ssIdx = (' + sst + '-1); __ssIdx <= (' + snd +' <= strlen(' + frStr + ')?' + snd +':strlen(' + frStr + '))-1; __ssIdx++) {\n__scBfr[__stIdx] = ' + frStr + '[__ssIdx]; __stIdx++; }\n';
+        code += 'strcpy(' + toStr + ', __scBfr);\n';
+    }
+    
+    return code;
+};
+
+Blockly.Blocks.string_compare = {
+  init: function() {
+    this.setColour(colorPalette.getColor('math'));
+    this.appendValueInput("STRA")
+        .setCheck("String")
+        .appendField("string");
+    this.appendValueInput("STRB")
+        .setCheck("String")
+        .appendField(new Blockly.FieldDropdown([["is the same as", "EQUAL"], ["is not the same as", "NOT"], ["is alphabetically before", "BEFORE"], ["is alphabetically after", "AFTER"]]), "COMP");
+    this.setInputsInline(true);
+    this.setOutput(true, "Number");
+  }
+};
+
+Blockly.propc.string_compare = function () {
+    var strA = Blockly.propc.valueToCode(this, 'STRA', Blockly.propc.ORDER_ATOMIC) || '';
+    var strB = Blockly.propc.valueToCode(this, 'STRB', Blockly.propc.ORDER_ATOMIC) || '';
+    var comp = this.getFieldValue('COMP');
+
+    Blockly.propc.definitions_['str_comp'] = 'int str_comp(char *__strA, char *__strB) { return strcmp(__strA, __strB); }';
+    
+    var code = '';
+
+    if(strA !== '' && strB !== '') {
+        if(comp === 'EQUAL') code += 'str_comp(' + strA + ', ' + strB + ') == 0';
+        if(comp === 'BEFORE') code += 'str_comp(' + strA + ', ' + strB + ') < 0';
+        if(comp === 'AFTER') code += 'str_comp(' + strA + ', ' + strB + ') > 0';
+        if(comp === 'NOT') code += 'str_comp(' + strA + ', ' + strB + ') != 0';  
+    } else {           
+        code += '0'; 
+    }
+    
+    return [code, Blockly.propc.ORDER_NONE];
 };

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -145,33 +145,67 @@
             <block type="controls_return"></block>
         </category>
         <category name="<fmt:message key="category.operators" />" colour="275">
-            <block type="math_arithmetic"></block>
-            <block type="math_limit"></block>
-            <block type="math_crement"></block>
-            <block type="math_random">
-                <value name="A">
-                    <block type="math_number">
-                        <field name="NUM">1</field>
-                    </block>
-                </value>
-                <value name="B">
-                     <block type="math_number">
-                        <field name="NUM">100</field>
-                    </block>
-                </value> 
-            </block>
-            <block type="math_bitwise"></block>
-            <block type="logic_operation"></block>
-            <block type="logic_negate"></block>
-            <block type="logic_compare"></block>
+            <category name="<fmt:message key="category.operators.numbers" />" >
+                <block type="math_arithmetic"></block>
+                <block type="math_limit"></block>
+                <block type="math_crement"></block>
+                <block type="math_random">
+                    <value name="A">
+                        <block type="math_number">
+                            <field name="NUM">1</field>
+                        </block>
+                    </value>
+                    <value name="B">
+                         <block type="math_number">
+                            <field name="NUM">100</field>
+                        </block>
+                    </value> 
+                </block>
+                <block type="math_bitwise"></block>
+                <block type="logic_operation"></block>
+                <block type="logic_negate"></block>
+                <block type="logic_compare"></block>
+            </category>
+            <category name="<fmt:message key="category.operators.strings" />" >
+                <block type="string_compare"></block>
+                <block type="string_length"></block>
+                <block type="combine_strings"></block>
+                <block type="find_substring"></block>
+                <block type="get_char_at_position">
+                    <value name="POSITION">
+                        <block type="math_number">
+                            <field name="NUM">1</field>
+                        </block>
+                    </value>
+                </block>
+                <block type="set_char_at_position">
+                    <value name="POSITION">
+                        <block type="math_number">
+                            <field name="NUM">1</field>
+                        </block>
+                    </value>
+                </block>
+                <block type="get_substring">
+                    <value name="START">
+                        <block type="math_number">
+                            <field name="NUM">1</field>
+                        </block>
+                    </value>
+                    <value name="END">
+                        <block type="math_number">
+                            <field name="NUM">3</field>
+                        </block>
+                    </value>
+                </block>
+            </category>            
         </category>
         <sep></sep>
         <category name="<fmt:message key="category.values" />" colour="220">
             <block type="math_number"></block>
             <block type="string_type_block"></block>
+            <block type="char_type_block"></block>            
             <block type="logic_boolean"></block>
             <block type="high_low_value"></block>
-            <block type="string_length"></block>
             <block type="color_picker"></block>
             <block type="color_value_from">
                 <value name="RED_VALUE">


### PR DESCRIPTION
Creates "number" and "string" subcategories under "Control", adds string manipulation and comparison blocks.  Updates Terminal print to allow single char printing to terminal as well.