### PR TITLE
Correct an ending DIV tag that was preventing proper OS detection.

### DIFF
--- a/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
@@ -16,7 +16,7 @@
                 <h4 class="modal-title"><fmt:message key="editor.client.title" /></h4>
             </div>
             <div class="modal-body">
-                <div id="client-instructions" data-url="<url:getUrl url="/public/clientinstructions"/>" />
+                <div id="client-instructions" data-url="<url:getUrl url="/public/clientinstructions"/>"></div>
                 <div class="clients">
                     <div class="client MacOS">
                         <img src="<url:getCdnUrl url="/images/os-icons/mac_os.png"/>"/>


### PR DESCRIPTION
Sometimes HTML and XML do not behave in the same way. Where a
would be legal XML, it is not acceptable HTML. Corrected the error with a
construct.