### PR TITLE
Remove empty SetToolTip calls

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -258,7 +258,6 @@ Blockly.Blocks.system_counter = {
         this.appendDummyInput()
             .appendField("system counter");
         this.setOutput(true, "Number");
-        this.setTooltip('');
   }
 };
 

--- a/src/main/webapp/cdn/blockly/generators/propc/math.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/math.js
@@ -77,7 +77,6 @@ Blockly.Blocks.math_limit = {
                 .appendField("and");
 
         this.setInputsInline(true);
-        this.setTooltip("limit");
         this.setOutput(true, 'Number');
         this.setPreviousStatement(false, null);
         this.setNextStatement(false, null);
@@ -110,7 +109,6 @@ Blockly.propc.math_limit.OPERATORS = {
 
 // Increment/decrement
 Blockly.Blocks.math_crement = {
-    // Rounding functions.
     helpUrl: Blockly.MSG_NUMBERS_HELPURL,
     init: function() {
 	this.setTooltip(Blockly.MSG_MATH_CREMENT_TOOLTIP);
@@ -118,8 +116,6 @@ Blockly.Blocks.math_crement = {
         this.appendValueInput('VAR')
             .setCheck('Number')
             .appendField(new Blockly.FieldDropdown(this.OPERATORS), 'OP');
-
-        this.setTooltip("");
         this.setPreviousStatement(true);
         this.setNextStatement(true);
     }
@@ -182,7 +178,12 @@ Blockly.Blocks.math_bitwise = {
         this.setColour(colorPalette.getColor('math'));
         this.appendValueInput('VAL1');
         this.appendDummyInput()
-            .appendField(new Blockly.FieldDropdown([["& (bitwise AND)", "&"], ["| (bitwise OR)", "|"], ["^ (bitwise XOR)", "^"], [">> (bitwise right shift)", ">>"], ["<< (bitwise left shift)", "<<"]]), "OPERATION");
+            .appendField(new Blockly.FieldDropdown([
+                ["& (bitwise AND)", "&"], 
+                ["| (bitwise OR)", "|"], 
+                ["^ (bitwise XOR)", "^"], 
+                [">> (bitwise right shift)", ">>"], 
+                ["<< (bitwise left shift)", "<<"]]), "OPERATION");
         this.appendValueInput('VAL2');
 
         this.setOutput(true, 'Number');

--- a/src/main/webapp/cdn/blockly/language/common/pins.js
+++ b/src/main/webapp/cdn/blockly/language/common/pins.js
@@ -66,7 +66,6 @@ Blockly.Blocks.check_pin = {
                 .appendField("check PIN")
                 .appendField(new Blockly.FieldDropdown(profile.default.digital), "PIN");
         this.setOutput(true, 'Number');
-        this.setTooltip('');
     }
 };
 
@@ -81,7 +80,6 @@ Blockly.Blocks.check_pin_input = {
                 .setCheck('Number');
         this.setOutput(true, 'Number');
         this.setInputsInline(true);
-        this.setTooltip('');
     }
 };
 


### PR DESCRIPTION
The block definitions had two tool tip function calls. The second, empty call obliterated the first tool tip call, destroying the tool tip message. Bahahhahaha