### PR TITLE
Remove unsed return function. Remove newline string from code generator.

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc/sensors.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/sensors.js
@@ -967,9 +967,9 @@ Blockly.propc.rfid_disable = function() {
     Blockly.propc.definitions_["rfidser"] = '#include "rfidser.h"';
 
     if(data === "ENABLE") {
-        return 'rfid_enable(rfid);\n';
+        return 'rfid_enable(rfid);';
     } else {
-        return 'rfid_disable(rfid);\n';    
+        return 'rfid_disable(rfid);';    
     }
 };
 

--- a/src/main/webapp/cdn/utils.js
+++ b/src/main/webapp/cdn/utils.js
@@ -74,7 +74,6 @@ var utils = {
             parr = parArr[i].split("=");
             if (parr[0] == parameter) {
                 return (decode) ? decodeURIComponent(parr[1]) : parr[1];
-                returnBool = true;
             } else {
                 returnBool = false;
             }


### PR DESCRIPTION
Unused return code appears to be an artifact from a previous refactor operation. 