### PR TITLE
Extend selectable pins from 13 to 17

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc.js
+++ b/src/main/webapp/cdn/blockly/generators/propc.js
@@ -142,7 +142,7 @@ var profile = {
             ["99", "32868"], ["100", "32869"]],
         baudrate: 115200,
         contiguous_pins_start: 0,
-        contiguous_pins_end: 13
+        contiguous_pins_end: 17
     },
     "s3": {
         description: "Scribbler Robot",


### PR DESCRIPTION
Pin selection on the Propeller Activity Board WX is currently set to the range of 0-13. This patch extends the range to 0-17.