### PR TITLE
Correct error handling in project retrieval code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ BlocklyProp.iml
 #################
 
 .idea
-
+*.iml
 
 #################
 ## Eclipse

--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectDaoImpl.java
@@ -37,15 +37,20 @@ public class ProjectDaoImpl implements ProjectDao {
 
     // Swap out old block definitions
     private ProjectRecord alterReadRecord(ProjectRecord record) {
+        String newCode;
         
-        String newCode = record.getCode();
-
-        // Return immediately if there is no code to adjust
-        if (newCode == null) {
-            return record;
+        if (record == null) {
+            throw new NullPointerException("Cannot alter a null project record.");
         }
-        
+
         try {
+            newCode = record.getCode();
+
+            // Return immediately if there is no code to adjust
+            if (newCode == null) {
+                return record;
+            }
+            
             if (record.getType() == ProjectType.SPIN) {
                 newCode = newCode.replaceAll("block type=\"controls_if\"", "block type=\"controls_boolean_if\"");
                 newCode = newCode.replaceAll("block type=\"logic_compare\"", "block type=\"logic_boolean_compare\"");

--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectDaoImpl.java
@@ -35,42 +35,54 @@ public class ProjectDaoImpl implements ProjectDao {
         this.create = dsl;
     }
 
+    // Swap out old block definitions
     private ProjectRecord alterReadRecord(ProjectRecord record) {
         
         String newCode = record.getCode();
-        if (record.getType() == ProjectType.SPIN) {
-            newCode = newCode.replaceAll("block type=\"controls_if\"", "block type=\"controls_boolean_if\"");
-            newCode = newCode.replaceAll("block type=\"logic_compare\"", "block type=\"logic_boolean_compare\"");
-            newCode = newCode.replaceAll("block type=\"logic_operation\"", "block type=\"logic_boolean_operation\"");
-            newCode = newCode.replaceAll("block type=\"logic_negate\"", "block type=\"logic_boolean_negate\"");
-            newCode = newCode.replaceAll("block type=\"math_number\"", "block type=\"spin_integer\"");
 
-        } else if (record.getType() == ProjectType.PROPC){
-            newCode = newCode.replaceAll("field name=\"OP\">ADD</field", "field name=\"OP\"> + </field");
-            newCode = newCode.replaceAll("field name=\"OP\">MINUS</field", "field name=\"OP\"> - </field");
-            newCode = newCode.replaceAll("field name=\"OP\">MULTIPLY</field", "field name=\"OP\"> * </field");
-            newCode = newCode.replaceAll("field name=\"OP\">DIVIDE</field", "field name=\"OP\"> / </field");
-            newCode = newCode.replaceAll("field name=\"OP\">MODULUS</field", "field name=\"OP\"> % </field");
-            newCode = newCode.replaceAll("field name=\"OP\">AND</field", "field name=\"OP\"> &amp;&amp; </field");
-            newCode = newCode.replaceAll("field name=\"OP\">AND_NOT</field", "field name=\"OP\"> &amp;&amp; !</field");
-
-            newCode = newCode.replaceAll("field name=\"OP\">LT</field", "field name=\"OP\">&lt;</field");
-            newCode = newCode.replaceAll("field name=\"OP\">GT</field", "field name=\"OP\">&gt;</field");
-            newCode = newCode.replaceAll("field name=\"OP\">LTE</field", "field name=\"OP\">&lt;=</field");
-            newCode = newCode.replaceAll("field name=\"OP\">GTE</field", "field name=\"OP\">&gt;=</field");
-            newCode = newCode.replaceAll("field name=\"OP\">EQ</field", "field name=\"OP\">==</field");
-            newCode = newCode.replaceAll("field name=\"OP\">NEQ</field", "field name=\"OP\">!=</field");
-
-            newCode = newCode.replaceAll("field name=\"UNIT\">INCHES</field", "field name=\"UNIT\">_inches</field");
-            newCode = newCode.replaceAll("field name=\"UNIT\">CM</field", "field name=\"UNIT\">_cm</field");
-            
-            newCode = newCode.replaceAll("block type=\"controls_boolean_if\"", "block type=\"controls_if\"");
-            newCode = newCode.replaceAll("block type=\"logic_boolean_compare\"", "block type=\"logic_compare\"");
-            newCode = newCode.replaceAll("block type=\"logic_boolean_operation\"", "block type=\"logic_operation\"");
-            newCode = newCode.replaceAll("block type=\"logic_boolean_negate\"", "block type=\"logic_negate\"");
-            
+        // Return immediately if there is no code to adjust
+        if (newCode == null) {
+            return record;
         }
-        record.setCode(newCode);
+        
+        try {
+            if (record.getType() == ProjectType.SPIN) {
+                newCode = newCode.replaceAll("block type=\"controls_if\"", "block type=\"controls_boolean_if\"");
+                newCode = newCode.replaceAll("block type=\"logic_compare\"", "block type=\"logic_boolean_compare\"");
+                newCode = newCode.replaceAll("block type=\"logic_operation\"", "block type=\"logic_boolean_operation\"");
+                newCode = newCode.replaceAll("block type=\"logic_negate\"", "block type=\"logic_boolean_negate\"");
+                newCode = newCode.replaceAll("block type=\"math_number\"", "block type=\"spin_integer\"");
+            } else if (record.getType() == ProjectType.PROPC){
+                newCode = newCode.replaceAll("field name=\"OP\">ADD</field", "field name=\"OP\"> + </field");
+                newCode = newCode.replaceAll("field name=\"OP\">MINUS</field", "field name=\"OP\"> - </field");
+                newCode = newCode.replaceAll("field name=\"OP\">MULTIPLY</field", "field name=\"OP\"> * </field");
+                newCode = newCode.replaceAll("field name=\"OP\">DIVIDE</field", "field name=\"OP\"> / </field");
+                newCode = newCode.replaceAll("field name=\"OP\">MODULUS</field", "field name=\"OP\"> % </field");
+                newCode = newCode.replaceAll("field name=\"OP\">AND</field", "field name=\"OP\"> &amp;&amp; </field");
+                newCode = newCode.replaceAll("field name=\"OP\">AND_NOT</field", "field name=\"OP\"> &amp;&amp; !</field");
+
+                newCode = newCode.replaceAll("field name=\"OP\">LT</field", "field name=\"OP\">&lt;</field");
+                newCode = newCode.replaceAll("field name=\"OP\">GT</field", "field name=\"OP\">&gt;</field");
+                newCode = newCode.replaceAll("field name=\"OP\">LTE</field", "field name=\"OP\">&lt;=</field");
+                newCode = newCode.replaceAll("field name=\"OP\">GTE</field", "field name=\"OP\">&gt;=</field");
+                newCode = newCode.replaceAll("field name=\"OP\">EQ</field", "field name=\"OP\">==</field");
+                newCode = newCode.replaceAll("field name=\"OP\">NEQ</field", "field name=\"OP\">!=</field");
+
+                newCode = newCode.replaceAll("field name=\"UNIT\">INCHES</field", "field name=\"UNIT\">_inches</field");
+                newCode = newCode.replaceAll("field name=\"UNIT\">CM</field", "field name=\"UNIT\">_cm</field");
+            
+                newCode = newCode.replaceAll("block type=\"controls_boolean_if\"", "block type=\"controls_if\"");
+                newCode = newCode.replaceAll("block type=\"logic_boolean_compare\"", "block type=\"logic_compare\"");
+                newCode = newCode.replaceAll("block type=\"logic_boolean_operation\"", "block type=\"logic_operation\"");
+                newCode = newCode.replaceAll("block type=\"logic_boolean_negate\"", "block type=\"logic_negate\"");
+            }
+
+            record.setCode(newCode);
+        }
+        
+        catch (Exception ex) {
+            System.out.print(ex.getMessage());
+        }
 
         return record;
     }
@@ -80,7 +92,6 @@ public class ProjectDaoImpl implements ProjectDao {
         ProjectRecord record = create.selectFrom(Tables.PROJECT).where(Tables.PROJECT.ID.equal(idProject)).fetchOne();
 
         return alterReadRecord(record);
-        //return record;
     }
 
     private ProjectRecord getProject(Long idProject, boolean toEdit) {
@@ -96,7 +107,6 @@ public class ProjectDaoImpl implements ProjectDao {
         }
 
         return alterReadRecord(record);
-        //return record;
     }
 
     @Override


### PR DESCRIPTION
Opening an existing project that contains older, retired block names and geometry were not always being converted correctly when being loaded. 