### PR TITLE
Configurable experimental code blocks

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/jsp/Properties.java
+++ b/src/main/java/com/parallax/server/blocklyprop/jsp/Properties.java
@@ -41,5 +41,18 @@ public class Properties {
         return configuration.getBoolean("oauth." + oauthProvider + ".enabled", true);
         }
     }
+    
+    // Use experimental menu items in test environment
+    public static boolean isExperimentalMenu(Boolean state) {
+        try {
+            if (configuration.getBoolean("experimental.menu") == true) {
+                return true;
+            }
+        } catch (java.util.NoSuchElementException ex) {
+            return false;
+        }
+        
+        return false;
+    }
 
 }

--- a/src/main/webapp/WEB-INF/properties.tld
+++ b/src/main/webapp/WEB-INF/properties.tld
@@ -22,4 +22,11 @@
         <function-class>com.parallax.server.blocklyprop.jsp.Properties</function-class>
         <function-signature>boolean isOauthEnabled(java.lang.String)</function-signature>
     </function>
+
+    <!-- Return flag to indicate if experimental menus are enabled  -->
+    <function>
+        <name>experimentalmenu</name>
+        <function-class>com.parallax.server.blocklyprop.jsp.Properties</function-class>
+        <function-signature>boolean isExperimentalMenu(java.lang.Boolean)</function-signature>
+    </function>
 </taglib>

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -1,6 +1,10 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
 
+<!-- Support for experimental blocks in Demo builds  -->
+<!-- See developer notes to use this feature         -->
+<c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
+
 <html>
     <head>
         <meta charset="utf-8">
@@ -606,7 +610,8 @@
                     </value>
                 </block>
             </category>
-
+<c:choose>
+    <c:when test="${experimental == true}">
             <category name="WX Module">
                 <category name="Simple">
                     <block type="wx_init"></block>
@@ -674,6 +679,8 @@
                     <block type="wx_ip"></block>
                 </category>
             </category>
+    </c:when>
+</c:choose>
 
             <category name="<fmt:message key="category.communicate.xbee" />">
                 <block type="xbee_setup"></block>
@@ -949,6 +956,9 @@
             <category name="<fmt:message key="category.sensor-input.ping" />">
                 <block type="sensor_ping"></block>
             </category>
+
+<c:choose>
+    <c:when test="${experimental == true}">
             <category name="<fmt:message key="category.sensor-input.fingerprint" />">
                 <block type="fp_scanner_init"></block>
                 <block type="fp_scanner_add">
@@ -960,6 +970,9 @@
                 </block>
                 <block type="fp_scanner_scan"></block>
             </category>
+    </c:when>
+</c:choose>
+    
             <category name="<fmt:message key="category.sensor-input.hmc5883l" />">
                 <block type="HMC5883L_init"></block>
                 <block type="HMC5883L_read"></block>


### PR DESCRIPTION
This update allows blocks of code in .jsp files to be enabled or disabled from a configuration file settings. This is done initially to disable blocks that have note been fully verified when an update is sent to production.

A new Boolean setting has been added to the blocklyprop.properties file:
experimental.menu = true

This setting will enable or disable code blocks in the framec.jsp file that are surrounded by specific JSTL tags.  If the property setting matches is set to true, the code between the <c:choose /> tags is included. Otherwise it is excluded. 

```
<c:choose>
    <c:when test="${experimental == true}">
            <category name="WX Module">
                 ...
            </category>
    </c:when>
</c:choose>

```