### PR TITLE
Update client download pages for change in MacOS distribution

### DIFF
--- a/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/clientdownload.jsp
@@ -20,7 +20,7 @@
                 <div class="clients">
                     <div class="client MacOS">
                         <img src="<url:getCdnUrl url="/images/os-icons/mac_os.png"/>"/>
-                        <a href="${properties:downloadfiles('/BlocklyPropClient-installer.dmg')}">
+                        <a href="${properties:downloadfiles('/BlocklyPropClient-setup-MacOS.pkg')}">
                             <fmt:message key="clientdownload.client.macos.installer" /></a>
                     </div>
                     <!-- Windows 32bit client -->

--- a/src/main/webapp/WEB-INF/servlet/clientdownload.jsp
+++ b/src/main/webapp/WEB-INF/servlet/clientdownload.jsp
@@ -42,7 +42,7 @@
                     <div class="clients">
                         <div class="client MacOS">
                             <img src="<url:getCdnUrl url="/images/os-icons/mac_os.png"/>"/>
-                            <a href="${properties:downloadfiles('/BlocklyPropClient-installer.dmg')}">
+                            <a href="${properties:downloadfiles('/BlocklyPropClient-setup-MacOS.pkg')}">
                                 <fmt:message key="clientdownload.client.macos.installer" /></a>
                         </div>
                         <div class="client Windows">


### PR DESCRIPTION
The BlocklyProp client installer for MacOS is now a pkg file. Update the links to reference the new file type. 