### PR TITLE
Update Apache Shiro to 1.3.2 to address security issue CVE-2016-6802

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         -->
 
         <jooq-version>3.6.4</jooq-version>
-        <shiro-version>1.2.3</shiro-version>
+        <shiro-version>1.3.2</shiro-version>
         <metrics-version>3.1.0</metrics-version>
         <jersey.version>1.19</jersey.version>
     </properties>


### PR DESCRIPTION
Reference security issue [CVE-2016-6802](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6802)

Apache Shiro before 1.3.2 allows attackers to bypass intended servlet filters and gain access by leveraging use of a non-root servlet context path. 