### PR TITLE
Move to java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,16 @@
     <packaging>war</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Adapt this to a version found on
            http://central.maven.org/maven2/org/eclipse/jetty/jetty-maven-plugin/
         -->
 
-        <jooq-version>3.6.4</jooq-version>
+        <!-- jOOQ version 3.7 and above requires Java 1.8.x JDK -->
+        <jooq-version>3.7.4</jooq-version>
+
         <shiro-version>1.3.2</shiro-version>
         <metrics-version>3.1.0</metrics-version>
         <jersey.version>1.19</jersey.version>
@@ -36,7 +38,12 @@
                 <directory>src/main/config/${environment}</directory>
             </resource>
         </resources>
+        
         <plugins>
+            <!--
+                codehaus.org shut down on 6/2015.
+                This is now the MojoHaus Project  http://www.mojohaus.org/
+            -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
@@ -60,15 +67,17 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${maven.compiler.source>}</source>
+                    <target>${maven.compiler.target}</target>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.6</version>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>
@@ -81,6 +90,7 @@
                     <update>true</update>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>

--- a/src/main/java/com/parallax/server/blocklyprop/security/BlocklyPropSessionDao.java
+++ b/src/main/java/com/parallax/server/blocklyprop/security/BlocklyPropSessionDao.java
@@ -34,8 +34,8 @@ public class BlocklyPropSessionDao implements SessionDAO {
     public Serializable create(Session session) {
         LOG.info("Create BlocklyProp session");
         
-        // Set session timeout for 2 hours
-        //session.setTimeout(7200000);
+        // Set session timeout for 1 hours
+        session.setTimeout(3600000);
         
         SimpleSession simpleSession = (SimpleSession) session;
         String uuid = UUID.randomUUID().toString();


### PR DESCRIPTION
Update the pom.xml to use java 1.8.x in preparation for package updates that require java 1.8.
Set the session timeout to a hard one hour limit because the current default is three minutes.