### PR TITLE
Trap NullPointerException that occurs when listing current projects

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/converter/ProjectConverter.java
+++ b/src/main/java/com/parallax/server/blocklyprop/converter/ProjectConverter.java
@@ -51,22 +51,31 @@ public class ProjectConverter {
 
     public JsonObject toListJson(ProjectRecord project) {
         JsonObject result = new JsonObject();
-        result.addProperty("id", project.getId());
-        result.addProperty("name", project.getName());
-        result.addProperty("description", project.getDescription());
-        result.addProperty("type", project.getType().name());
-        result.addProperty("board", project.getBoard());
-        result.addProperty("private", project.getPrivate());
-        result.addProperty("shared", project.getShared());
-        result.addProperty("created", DateConversion.toDateTimeString(project.getCreated().getTime()));
-        result.addProperty("modified", DateConversion.toDateTimeString(project.getModified().getTime()));
-        boolean isYours = project.getIdUser().equals(BlocklyPropSecurityUtils.getCurrentUserId());
-        result.addProperty("yours", isYours);
-        // if (!isYours) {
-        result.addProperty("user", userService.getUserScreenName(project.getIdUser()));
-        result.addProperty("id-user", project.getIdUser());
-        // }
 
+        if (project != null) {
+            result.addProperty("id", project.getId());
+            result.addProperty("name", project.getName());
+            result.addProperty("description", project.getDescription());
+            result.addProperty("type", project.getType().name());
+            result.addProperty("board", project.getBoard());
+            result.addProperty("private", project.getPrivate());
+            result.addProperty("shared", project.getShared());
+            result.addProperty("created", DateConversion.toDateTimeString(project.getCreated().getTime()));
+            result.addProperty("modified", DateConversion.toDateTimeString(project.getModified().getTime()));
+        
+            boolean isYours = project.getIdUser().equals(BlocklyPropSecurityUtils.getCurrentUserId());
+            result.addProperty("yours", isYours);
+
+            // Get user screen name only if it's a registered user
+            if (project.getId() > 0) {
+                result.addProperty("user", userService.getUserScreenName(project.getIdUser()));
+                result.addProperty("id-user", project.getIdUser());
+            }
+            else {
+                result.addProperty("user", "anonymous");
+                result.addProperty("id-user", 0);
+            }
+        }
         return result;
     }
 

--- a/src/main/java/com/parallax/server/blocklyprop/rest/RestSharedProject.java
+++ b/src/main/java/com/parallax/server/blocklyprop/rest/RestSharedProject.java
@@ -58,14 +58,22 @@ public class RestSharedProject {
     @Detail("Get all shared projects")
     @Name("Get all shared projects")
     @Produces("application/json")
-    public Response get(@QueryParam("sort") TableSort sort, @QueryParam("order") TableOrder order, @QueryParam("limit") Integer limit, @QueryParam("offset") Integer offset) {
+    public Response get(
+            @QueryParam("sort") TableSort sort, 
+            @QueryParam("order") TableOrder order, 
+            @QueryParam("limit") Integer limit, 
+            @QueryParam("offset") Integer offset) {
+        
         LOG.info("Sort: {}", sort);
 
-        List<ProjectRecord> projects = projectService.getSharedProjects(sort, order, limit, offset);
+        List<ProjectRecord> projects 
+                = projectService.getSharedProjects(sort, order, limit, offset);
+        
         int projectCount = projectService.countSharedProjects();
 
         JsonObject result = new JsonObject();
         JsonArray jsonProjects = new JsonArray();
+        
         for (ProjectRecord project : projects) {
             jsonProjects.add(projectConverter.toListJson(project));
         }

--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/UserServiceImpl.java
@@ -64,7 +64,16 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public String getUserScreenName(Long idUser) {
-        return userDao.getUser(idUser).getScreenname();
+        
+        String name = "";
+        
+        try {
+            name = userDao.getUser(idUser).getScreenname();
+        }
+        catch (NullPointerException ex) {
+            LOG.error("Error retreiving name for userID: {}", idUser);
+        }
+        return name;
     }
 
     @Override


### PR DESCRIPTION
The error occurs while retrieving the screen name associated with the owner of each project in the list. If the user record has been removed, the screen name is unavailable. The code assumes that the user record is always available. 

The larger question is why a user record can be removed while it still owns projects. 