### PR TITLE
Bug fixes: variables, graphing, add grayscale feature

### DIFF
--- a/src/main/webapp/cdn/blockly/generators/propc.js
+++ b/src/main/webapp/cdn/blockly/generators/propc.js
@@ -112,6 +112,21 @@ var colorPalette = {
         'protocols': 340,
         'system': 320
     },
+    grayscaleColors: {
+        'input': '#AAAAAA',
+        'output': '#222222',
+        'io': '#333333',
+        'programming': '#444444',
+        'functions': '#555555',
+        'variables': '#666666',
+        'math': '#777777',
+        'binary': '#777777',
+        'robot': '#888888',
+        'heb': '#888888',
+        'ab': '#999999',
+        'protocols': '#111111',
+        'system': '#999999'
+    },
     activePalette: null,
     getColor: function (type) {
         if (colorPalette.activePalette && colorPalette.activePalette[type] !== undefined) {
@@ -123,7 +138,11 @@ var colorPalette = {
 
 };
 
-colorPalette.activePalette = colorPalette.defaultColors;
+if (document.referrer.split('?')[1].indexOf('grayscale=1') === -1 ) {
+    colorPalette.activePalette = colorPalette.defaultColors;
+} else {
+    colorPalette.activePalette = colorPalette.grayscaleColors;
+}
 
 
 

--- a/src/main/webapp/cdn/blockly/generators/propc/base.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/base.js
@@ -31,31 +31,6 @@
 if (!Blockly.Blocks)
     Blockly.Blocks = {};
 
-/*
- Blockly.Blocks.number_range = {
- helpUrl: Blockly.MSG_VALUES_HELPURL,
- init: function () {
- this.setTooltip(Blockly.MSG_MATH_NUMBER_TOOLTIP);
- this.setColour(colorPalette.getColor('programming'));
- this.appendDummyInput()
- .appendField(new Blockly.FieldTextInput('0',
- Blockly.FieldTextInput.numberValidator), 'NUM');
- this.setOutput(true, 'Number');
- }
- };
- 
- Blockly.propc.number_range = function () {
- // Numeric value.
- var code = window.parseInt(this.getFieldValue('NUM'));
- // -4.abs() returns -4 in Dart due to strange order of operation choices.
- // -4 is actually an operator and a number.  Reflect this in the order.
- var order = code < 0 ?
- Blockly.propc.ORDER_UNARY_PREFIX : Blockly.propc.ORDER_ATOMIC;
- return [code, order];
- };
- */
-
-
 // Number block that can mutate to show a range or if a value
 // is out bounds or not available.  Gets values from the block its connected
 // to by looking for a hidden field starting with "RANGEVALS".
@@ -1270,7 +1245,7 @@ Blockly.Blocks.combine_strings = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -1350,7 +1325,7 @@ Blockly.Blocks.get_char_at_position = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -1392,7 +1367,7 @@ Blockly.Blocks.set_char_at_position = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -1431,9 +1406,9 @@ Blockly.Blocks.get_substring = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('FROM_STR')))
-            this.setTitleValue(newName, 'FROM_STR');
+            this.setFieldValue(newName, 'FROM_STR');
         if (Blockly.Names.equals(oldName, this.getFieldValue('TO_STR')))
-            this.setTitleValue(newName, 'TO_STR');
+            this.setFieldValue(newName, 'TO_STR');
     }
 };
 
@@ -1515,7 +1490,7 @@ Blockly.Blocks.string_to_number = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };
@@ -1556,7 +1531,7 @@ Blockly.Blocks.number_to_string = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };
@@ -1670,7 +1645,7 @@ Blockly.Blocks.math_advanced = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('STORE'))) {
-            this.setTitleValue(newName, 'STORE');
+            this.setFieldValue(newName, 'STORE');
         }
     }
 };
@@ -1719,7 +1694,7 @@ Blockly.Blocks.math_inv_trig = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('STORE'))) {
-            this.setTitleValue(newName, 'STORE');
+            this.setFieldValue(newName, 'STORE');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/communicate.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/communicate.js
@@ -140,7 +140,7 @@ Blockly.Blocks.console_scan_text = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 
@@ -179,7 +179,7 @@ Blockly.Blocks.console_scan_number = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 
@@ -410,7 +410,7 @@ Blockly.Blocks.serial_rx = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -452,7 +452,7 @@ Blockly.Blocks.serial_receive_text = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -903,7 +903,7 @@ Blockly.Blocks.xbee_receive = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };
@@ -2259,10 +2259,10 @@ Blockly.Blocks.wx_scan_multiple = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         for (var i = 0; i < this.optionList_.length; i++) {
             if (Blockly.Names.equals(oldName, this.getFieldValue('CPU' + i)))
-                this.setTitleValue(newName, 'CPU' + i);
+                this.setFieldValue(newName, 'CPU' + i);
 
         }
     }
@@ -2470,7 +2470,7 @@ Blockly.Blocks.wx_print_multiple = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE'))) {
-            this.setTitleValue(newName, 'HANDLE');
+            this.setFieldValue(newName, 'HANDLE');
         }
     }
 };
@@ -2588,9 +2588,9 @@ Blockly.Blocks.wx_scan_string = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setTitleValue(newName, 'HANDLE');
+            this.setFieldValue(newName, 'HANDLE');
         if (Blockly.Names.equals(oldName, this.getFieldValue('VARNAME')))
-            this.setTitleValue(newName, 'VARNAME');
+            this.setFieldValue(newName, 'VARNAME');
     }
 };
 
@@ -2636,7 +2636,7 @@ Blockly.Blocks.wx_send_string = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE'))) {
-            this.setTitleValue(newName, 'HANDLE');
+            this.setFieldValue(newName, 'HANDLE');
         }
     }
 };
@@ -2680,11 +2680,11 @@ Blockly.Blocks.wx_receive_string = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('DATA')))
-            this.setTitleValue(newName, 'DATA');
+            this.setFieldValue(newName, 'DATA');
         if (Blockly.Names.equals(oldName, this.getFieldValue('BYTES')))
-            this.setTitleValue(newName, 'BYTES');
+            this.setFieldValue(newName, 'BYTES');
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setTitleValue(newName, 'HANDLE');
+            this.setFieldValue(newName, 'HANDLE');
     }
 };
 
@@ -2725,11 +2725,11 @@ Blockly.Blocks.wx_poll = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID')))
-            this.setTitleValue(newName, 'ID');
+            this.setFieldValue(newName, 'ID');
         if (Blockly.Names.equals(oldName, this.getFieldValue('EVENT')))
-            this.setTitleValue(newName, 'EVENT');
+            this.setFieldValue(newName, 'EVENT');
         if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setTitleValue(newName, 'HANDLE');
+            this.setFieldValue(newName, 'HANDLE');
     }
 };
 
@@ -2812,15 +2812,15 @@ Blockly.Blocks.wx_listen = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID')))
-            this.setTitleValue(newName, 'ID');
+            this.setFieldValue(newName, 'ID');
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID1')))
-            this.setTitleValue(newName, 'ID1');
+            this.setFieldValue(newName, 'ID1');
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID2')))
-            this.setTitleValue(newName, 'ID2');
+            this.setFieldValue(newName, 'ID2');
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID3')))
-            this.setTitleValue(newName, 'ID3');
+            this.setFieldValue(newName, 'ID3');
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID4')))
-            this.setTitleValue(newName, 'ID4');
+            this.setFieldValue(newName, 'ID4');
     }
 };
 
@@ -3048,7 +3048,7 @@ Blockly.Blocks.wx_buffer = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setTitleValue(newName, 'BUFFER');
+            this.setFieldValue(newName, 'BUFFER');
         }
     }
 };
@@ -3115,7 +3115,7 @@ Blockly.Blocks.wx_disconnect = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('ID'))) {
-            this.setTitleValue(newName, 'ID');
+            this.setFieldValue(newName, 'ID');
         }
     }
 };
@@ -3267,14 +3267,6 @@ Blockly.Blocks.graph_output = {
         if (this.getInput('PRINT0') && this.getInput('PRINTa')) {
             this.removeInput('PRINTa');
             this.removeInput('PRINTb');
-        }
-    },
-    getVars: function () {
-        return [this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE'))) {
-            this.setTitleValue(newName, 'HANDLE');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/control.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/control.js
@@ -392,7 +392,7 @@ Blockly.Blocks.control_repeat_for_loop = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/gpio.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/gpio.js
@@ -556,7 +556,7 @@ Blockly.Blocks.eeprom_read = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setTitleValue(newName, 'VALUE');
+            this.setFieldValue(newName, 'VALUE');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/heb.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/heb.js
@@ -545,9 +545,9 @@ Blockly.Blocks.heb_ir_read_signal = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER')))
-            this.setTitleValue(newName, 'BUFFER');
+            this.setFieldValue(newName, 'BUFFER');
         if (Blockly.Names.equals(oldName, this.getFieldValue('LENGTH')))
-            this.setTitleValue(newName, 'LENGTH');
+            this.setFieldValue(newName, 'LENGTH');
     }
 };
 
@@ -644,7 +644,7 @@ Blockly.Blocks.heb_badge_eeprom_retrieve = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setTitleValue(newName, 'BUFFER');
+            this.setFieldValue(newName, 'BUFFER');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/s3.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/s3.js
@@ -1049,8 +1049,12 @@ Blockly.Blocks.stall_sensor = {
         this.appendDummyInput("")
                 .appendField("stall sensor")
                 .appendField(new Blockly.FieldDropdown([
-                    ["tail wheel", "s3_stalled()"],
-                    ["drive wheels", "!s3_motorsMoving()"]
+                    ["tail wheel is stopped", "s3_stalled()"],
+                    ["tail wheel is spinning", "!s3_stalled()"],
+                    ["drive wheels stalled", "!s3_motorsMoving()"],
+                    ["drive wheels turning", "s3_motorsMoving()"],
+                    ["Scribbler is stuck", "s3_simpleStalled(S3_IS)"],
+                    ["Scribbler is not stuck", "s3_simpleStalled(S3_IS_NOT)"]
                 ]), "STALL_SENSOR_CHOICE");
         this.setOutput(true, "Number");
         this.setColour(colorPalette.getColor('input'));
@@ -1207,6 +1211,7 @@ Blockly.propc.scribbler_ping = function () {
     return [code, Blockly.propc.ORDER_ATOMIC];
 };
 
+/*
 Blockly.Blocks.digital_input = {
     init: function () {
         this.appendDummyInput("")
@@ -1257,6 +1262,7 @@ Blockly.propc.digital_output = function () {
             return 'reverse(' + dropdown_pin + ');\n';
     }
 };
+*/
 
 Blockly.Blocks.analog_input = {
     init: function () {
@@ -1276,6 +1282,7 @@ Blockly.propc.analog_input = function () {
     return ['s3_readADC(S3_ADC_A' + pin + ')', Blockly.propc.ORDER_ATOMIC];
 };
 
+/*
 Blockly.Blocks.spin_integer = {
     init: function () {
         this.appendDummyInput('MAIN')
@@ -1446,6 +1453,7 @@ Blockly.propc.math_int_angle = function () {
             Blockly.propc.ORDER_UNARY_PREFIX : Blockly.propc.ORDER_ATOMIC;
     return [code, order];
 };
+*/
 
 Blockly.Blocks.scribbler_boolean = {
     init: function () {
@@ -1496,6 +1504,7 @@ Blockly.Blocks.scribbler_random_number = {
     }
 };
 
+/*
 Blockly.propc.scribbler_random_number = function () {
     Blockly.propc.setups_["random_seed"] = "srand(INA + CNT);\n";
     var arg1 = Blockly.propc.valueToCode(this, 'A', Blockly.propc.ORDER_ATOMIC) || '0';
@@ -1523,6 +1532,7 @@ Blockly.propc.spin_comment = function () {
 
     return '// ' + text + '\n';
 };
+*/
 
 Blockly.Blocks.factory_reset = {
     init: function () {

--- a/src/main/webapp/cdn/blockly/generators/propc/sensors.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/sensors.js
@@ -280,11 +280,11 @@ Blockly.Blocks.colorpal_get_colors_raw = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('R_STORAGE'))) {
-            this.setTitleValue(newName, 'R_STORAGE');
+            this.setFieldValue(newName, 'R_STORAGE');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('G_STORAGE'))) {
-            this.setTitleValue(newName, 'G_STORAGE');
+            this.setFieldValue(newName, 'G_STORAGE');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('B_STORAGE'))) {
-            this.setTitleValue(newName, 'B_STORAGE');
+            this.setFieldValue(newName, 'B_STORAGE');
         }
     }
 };
@@ -315,7 +315,7 @@ Blockly.Blocks.colorpal_get_colors = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('COLOR'))) {
-            this.setTitleValue(newName, 'COLOR');
+            this.setFieldValue(newName, 'COLOR');
         }
     }
 };
@@ -670,11 +670,11 @@ Blockly.Blocks.MMA7455_acceleration = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('X_VAR'))) {
-            this.setTitleValue(newName, 'X_VAR');
+            this.setFieldValue(newName, 'X_VAR');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('Y_VAR'))) {
-            this.setTitleValue(newName, 'Y_VAR');
+            this.setFieldValue(newName, 'Y_VAR');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('Z_VAR'))) {
-            this.setTitleValue(newName, 'Z_VAR');
+            this.setFieldValue(newName, 'Z_VAR');
         }
     }
 };
@@ -737,7 +737,7 @@ Blockly.Blocks.HMC5883L_read = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('HEADING'))) {
-            this.setTitleValue(newName, 'HEADING');
+            this.setFieldValue(newName, 'HEADING');
         }
     }
 };
@@ -831,11 +831,11 @@ Blockly.Blocks.lsm9ds1_read = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('X_VAR'))) {
-            this.setTitleValue(newName, 'X_VAR');
+            this.setFieldValue(newName, 'X_VAR');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('Y_VAR'))) {
-            this.setTitleValue(newName, 'Y_VAR');
+            this.setFieldValue(newName, 'Y_VAR');
         } else if (Blockly.Names.equals(oldName, this.getFieldValue('Z_VAR'))) {
-            this.setTitleValue(newName, 'Z_VAR');
+            this.setFieldValue(newName, 'Z_VAR');
         }
     }
 };
@@ -925,9 +925,9 @@ Blockly.Blocks.lsm9ds1_tilt = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR1')))
-            this.setTitleValue(newName, 'VAR1');
+            this.setFieldValue(newName, 'VAR1');
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR2')))
-            this.setTitleValue(newName, 'VAR2');
+            this.setFieldValue(newName, 'VAR2');
     }
 };
 
@@ -1035,7 +1035,7 @@ Blockly.Blocks.lsm9ds1_heading = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };
@@ -1368,7 +1368,7 @@ Blockly.Blocks.rfid_get = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setTitleValue(newName, 'BUFFER');
+            this.setFieldValue(newName, 'BUFFER');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/generators/propc/variables.js
+++ b/src/main/webapp/cdn/blockly/generators/propc/variables.js
@@ -50,7 +50,7 @@ Blockly.Blocks.variables_get = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };
@@ -75,7 +75,7 @@ Blockly.Blocks.variables_declare = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };
@@ -99,7 +99,7 @@ Blockly.Blocks.variables_set = {
     },
     renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setTitleValue(newName, 'VAR');
+            this.setFieldValue(newName, 'VAR');
         }
     }
 };

--- a/src/main/webapp/cdn/blockly/toolboxfilter.js
+++ b/src/main/webapp/cdn/blockly/toolboxfilter.js
@@ -31,6 +31,23 @@ function filterToolbox(profileName, peripherals) {
             if (graphing)
                 toolboxEntry.remove();
         }
+        if (document.referrer.split('?')[1].indexOf('grayscale=1') > -1) {
+            var colorChanges = {
+                '140': '#AAAAAA',
+                '165': '#222222',
+                '185': '#333333',
+                '205': '#444444',
+                '225': '#555555',
+                '250': '#666666',
+                '275': '#777777',
+                '295': '#888888',
+                '320': '#999999',
+                '340': '#111111'
+            };
+            var colour = toolboxEntry.attr('colour');
+            if (colour)
+                toolboxEntry.attr('colour', colorChanges[colour]);
+        }
     });
     $("#toolbox").find('sep').each(function () {
         var toolboxEntry = $(this);

--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -596,7 +596,8 @@ function graph_new_data(stream) {
 function graph_reset() {
     clearInterval(graph_interval_id);
     graph_interval_id = null;
-    graph_temp_data.length = 0;
+    graph_temp_data = null;
+    graph_temp_data = new Array;
     graph_data = {
         series: [// add more here for more possible lines...
             [],

--- a/src/main/webapp/frame/framec.jsp
+++ b/src/main/webapp/frame/framec.jsp
@@ -82,7 +82,7 @@
     </head>
     <body  onload="ready()" >
     <xml id="toolbox" style="display: none">
-        <category name="<fmt:message key="category.control" />" exclude="s3" colour="220">
+        <category name="<fmt:message key="category.control" />" exclude="s3" colour="205">
             <block type="comment"></block>
             <block type="controls_if"></block>
             <block type="controls_repeat">
@@ -195,7 +195,7 @@
         </category>
         <sep></sep>
         <!-- IF THIS MENU GETS CHANGED BE SURE TO CHANGE THE FOLLOWING MENU AS WELL -->
-        <category name="<fmt:message key="category.values" />" include="other" colour="220">
+        <category name="<fmt:message key="category.values" />" include="other" colour="275">
             <block type="math_number"></block>
             <block type="string_type_block"></block>
             <block type="char_type_block"></block>
@@ -236,7 +236,7 @@
             </block>
         </category>
         <!-- IF THIS MENU GETS CHANGED BE SURE TO CHANGE THE PREVIOUS MENU AS WELL -->
-        <category name="<fmt:message key="category.values" />" include="heb" colour="220">
+        <category name="<fmt:message key="category.values" />" include="heb" colour="205">
             <block type="math_number"></block>
             <block type="string_type_block"></block>
             <block type="char_type_block"></block>
@@ -247,7 +247,7 @@
             <block type="heb_color_val"></block>
             <block type="system_counter"></block>
         </category>
-        <category name="<fmt:message key="category.values" />" include="activity-board,flip" colour="220">
+        <category name="<fmt:message key="category.values" />" include="activity-board,flip" colour="205">
             <block type="math_number"></block>
             <block type="string_type_block"></block>
             <block type="char_type_block"></block>
@@ -391,7 +391,7 @@
             </block>
             <block type="comment"></block>
         </category>
-        <category name="<fmt:message key="category.variables" />" custom="VARIABLE" colour="260"></category>
+        <category name="<fmt:message key="category.variables" />" custom="VARIABLE" colour="250"></category>
         <category name="<fmt:message key="category.operators.arrays" />" include="s3" colour="250">
             <block type="array_init"></block>
             <block type="array_fill"></block>
@@ -416,8 +416,8 @@
             </block>
             <block type="array_clear"></block>
         </category>
-        <category name="<fmt:message key="category.functions" />" custom="PROCEDURE" colour="240"></category>
-        <category name="<fmt:message key="category.input-output.pin-states" />" exclude="s3,heb" colour="200">
+        <category name="<fmt:message key="category.functions" />" custom="PROCEDURE" colour="225"></category>
+        <category name="<fmt:message key="category.input-output.pin-states" />" exclude="s3,heb" colour="185">
             <block type="make_pin"></block>
             <block type="make_pin_input">
                 <value name="PIN">
@@ -441,14 +441,14 @@
                     <block type="number_binary"></block>
                 </value>
         </category>
-        <category name="<fmt:message key="category.communicate.graphing" />" graphing="1" include="activity-board,flip,other" colour="320">
+        <category name="<fmt:message key="category.communicate.graphing" />" graphing="1" include="activity-board,flip,other" colour="340">
             <block type="graph_settings">
                 <field name="RATE">250</field>
                 <field name="XAXIS">40,S</field>
             </block>                
             <block type="graph_output"></block>
         </category>
-        <category name="<fmt:message key="category.communicate" />" include="activity-board,flip,other" colour="320">
+        <category name="<fmt:message key="category.communicate" />" include="activity-board,flip,other" colour="340">
             <category name="<fmt:message key="category.communicate.oled" />">
                 <block type="oled_initialize"></block>
                 <block type="oled_font_loader"></block>
@@ -797,7 +797,7 @@
 
         <sep include="heb"></sep>
 
-        <category name="<fmt:message key="category.communicate" />" include="heb" colour="320">
+        <category name="<fmt:message key="category.communicate" />" include="heb" colour="340">
             <category name="<fmt:message key="category.communicate.serial-terminal" />">
                 <block type="console_print">
                     <value name="MESSAGE">
@@ -976,7 +976,7 @@
                 <block type="heb_ir_clear_buffer"></block>
             </category>
         </category>
-        <category name="<fmt:message key="category.audio" />" include="heb" colour="290">
+        <category name="<fmt:message key="category.audio" />" include="heb" colour="295">
             <category name="<fmt:message key="category.hackable-electronic-badge.text-to-speech" />">
                 <block type="heb_text_to_speech_say">
                     <value name="STRING">
@@ -1048,7 +1048,7 @@
             <block type="heb_count_contacts"></block>
             <block type="heb_erase_all_contacts"></block>
         </category>
-        <category name="<fmt:message key="category.sensor-input" />" exclude="s3,heb" colour="155">
+        <category name="<fmt:message key="category.sensor-input" />" exclude="s3,heb" colour="140">
             <category name="<fmt:message key="category.sensor-input.2axis-joystick" />" include="activity-board">
                 <block type="joystick_input_xaxis"></block>
                 <block type="joystick_input_yaxis"></block>
@@ -1135,7 +1135,7 @@
                 <block type="sound_impact_end"></block>
             </category>
         </category>
-        <category name="<fmt:message key="category.memory" />" include="activity-board,flip,other" colour="155">
+        <category name="<fmt:message key="category.memory" />" include="activity-board,flip,other" colour="165">
             <category name="<fmt:message key="category.memory.eeprom" />">
                 <block type="eeprom_read">
                     <value name="ADDRESS">
@@ -1153,7 +1153,7 @@
                 </block>
             </category>
         </category>
-        <category name="<fmt:message key="category.analog-pulses" />" exclude="s3,heb" colour="200">
+        <category name="<fmt:message key="category.analog-pulses" />" exclude="s3,heb" colour="185">
             <category name="<fmt:message key="category.analog-pulses.pulse-in-out" />" exclude="s3">
                 <block type="pulse_in"></block>
                 <block type="pulse_out">
@@ -1200,7 +1200,7 @@
                 <block type="mcp320x_set_vref"></block>
             </category>
         </category>
-        <category name="<fmt:message key="category.audio" />" exclude="s3,heb" colour="200">
+        <category name="<fmt:message key="category.audio" />" exclude="s3,heb" colour="185">
             <category name="<fmt:message key="category.audio.freqout" />" exclude="s3">
                 <block type="base_freqout">
                     <value name="DURATION">
@@ -1228,7 +1228,7 @@
                 <block type="wav_stop"></block>
             </category>
         </category>
-        <category name="<fmt:message key="category.servo" />" exclude="s3,heb" colour="180">
+        <category name="<fmt:message key="category.servo" />" exclude="s3,heb" colour="165">
             <category name="<fmt:message key="category.servo.standard-servo" />">
                 <block type="servo_move">
                     <value name="ANGLE">
@@ -1295,7 +1295,7 @@
             <block type="activitybot_calibrate"></block>
             <block type="activitybot_display_calibration"></block>
         </category>
-        <category name="<fmt:message key="category.s3-math" />" include="s3" colour=275>
+        <category name="<fmt:message key="category.s3-math" />" include="s3" colour="275">
             <block type="math_number"></block>
             <block type="scribbler_boolean"></block>
             <block type="scribbler_random_boolean"></block>
@@ -1359,7 +1359,7 @@
                 <block type="reset_button_presses"></block>
             </category>
         </category>
-        <category name="<fmt:message key="category.s3-actions" />" include="s3" colour=185>
+        <category name="<fmt:message key="category.s3-actions" />" include="s3" colour="185">
             <category name="<fmt:message key="category.s3-actions.motors" />">
                 <block type="scribbler_drive">
                     <field name="DRIVE_ANGLE">STRAIGHT</field>


### PR DESCRIPTION
Initial addition of a "view in grayscale" feature #1039 - double wrapped, uses URL tag to activate
Bug fixes:
- bug related to variable renaming introduced by me forgetting to remove renaming handlers from a block that didn't contain variables.
- changed all "setTitleValue" to "setFieldValue" - setTitleValue is deprecated.
- bug in graphing modal where data on the graph wasn't properly cleared out and caused a re-opening of the graphing window to choke
- matched colors in the toolbox labels to the colors of the blocks (blocks were changed some time ago, but the toolbox menu didn't keep up)
- commented out now unused S3 C blocks #1026 
- re-add menu options to S3 is stalled block that were lost in the initial switchover