### PR TITLE
Add code to handle a possible uninitialized object

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/UserServiceImpl.java
@@ -54,12 +54,25 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public User getUser(Long idUser) {
-        return userDao.getUser(idUser).into(User.class);
+        if (userDao != null) {
+            return userDao.getUser(idUser).into(User.class);
+        }
+        else {
+            LOG.error("UserDAO is not initialized before first use!");
+            return null;
+        }
+        
     }
 
     @Override
     public List<UserRecord> getAllUsers() {
-        return userDao.getAll();
+        if (userDao != null) {
+            return userDao.getAll();
+        }
+        else {
+            LOG.error("UserDAO is not initialized before first use!");
+            return null;
+        }
     }
 
     @Override
@@ -68,7 +81,12 @@ public class UserServiceImpl implements UserService {
         String name = "";
         
         try {
-            name = userDao.getUser(idUser).getScreenname();
+            if (userDao != null) {
+                name = userDao.getUser(idUser).getScreenname();
+            }
+            else {
+                LOG.error("UserDAO is not initialized before first use!");
+            }
         }
         catch (NullPointerException ex) {
             LOG.error("Error retreiving name for userID: {}", idUser);


### PR DESCRIPTION
The userDao object is not explicitly initialized in the constructor. It is used in a few class methods without verifying that it has been initialized. This triggers a NullPointerException. This patch verifies that the object reference is not null before using it.
