### PR TITLE
Add missing doctype; Add MOTD placeholder

### DIFF
--- a/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
@@ -75,4 +75,14 @@
             </span>
         </div>
     </div>
+    <!-- Message of the Day goes here. -->
+    <!--
+        <div class="navbar navbar-expand" style="background-color: #b2dba1 ">
+            <div class="container-fluid">
+                <span style="alignment-adjust: middle"> 
+                    Message of the day goes here
+                </span>
+            </div>
+        </div>
+    -->
 </nav>

--- a/src/main/webapp/WEB-INF/servlet/index.jsp
+++ b/src/main/webapp/WEB-INF/servlet/index.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!doctype html >
 <html>
     <head>
         <meta name="application-name" content="&nbsp;"/>


### PR DESCRIPTION
HTML 5 pages should begin with a <!doctype html> attribute. That attribute was missing in the index.jsp page.

Add a basic framework for the MOTD feature referenced in #1154.  