### PR TITLE
send data to terminal that arrives between connection string and flag…

### DIFF
--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -433,7 +433,10 @@ function serial_console() {
                         connStrYet = true;
                         if(document.getElementById('serial-conn-info')) {
                             document.getElementById('serial-conn-info').innerHTML = connString.trim();
+                            // send remainder of string to terminal???  Haven't seen any leak through yet...
                         }
+                    } else {
+                        displayInTerm(e.data);
                     }
                 }
                 $('#serial_console').focus();


### PR DESCRIPTION
… being set.  Data sent immediately to the terminal using the BPC is getting dumped when it arrives before the connection string is detected and that flag is set.