### PR TITLE
Disable Jooq code generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>
                 <version>${jooq-version}</version>
+                <!--
                                 <executions>
                                     <execution>
                                         <goals>
@@ -102,6 +103,7 @@
                                         </goals>
                                     </execution>
                                 </executions>
+                -->
                 <dependencies>
                     <dependency>
                         <groupId>mysql</groupId>


### PR DESCRIPTION
Jenkins does not like to do code generation on missing tables.