### PR TITLE
Disable session management.

### DIFF
--- a/src/main/resources/shiro.ini
+++ b/src/main/resources/shiro.ini
@@ -18,12 +18,21 @@ sessionDao = com.parallax.server.blocklyprop.security.BlocklyPropSessionDao
 securityManager.sessionManager.sessionDAO = $sessionDao
 securityManager.sessionManager.sessionIdCookieEnabled = true
 
-# sessionValidationScheduler = org.apache.shiro.session.mgt.ExecutorServiceSessionValidationScheduler
-# sessionValidationScheduler.interval = 86400000
+# Attach the default session validation scheduler
+sessionValidationScheduler = org.apache.shiro.session.mgt.ExecutorServiceSessionValidationScheduler
 
-# securityManager.sessionManager.sessionValidationScheduler = $sessionValidationScheduler
+# Run once per day
+sessionValidationScheduler.interval = 86400000
 
-# Disable scheduler in a multi-host environment
+# TESTING - Run every 30 seconds
+# sessionValidationScheduler.interval = 300000
+
+securityManager.sessionManager.sessionValidationScheduler = $sessionValidationScheduler
+
+# --------------------------------------------------------------------------
+# Disable session management when operating within a multi-host environment
+# --------------------------------------------------------------------------
+securityManager.sessionManager.deleteInvalidSessions = false
 securityManager.sessionManager.sessionValidationSchedulerEnabled = false
 
 # Set global default session timeout to eight hours


### PR DESCRIPTION
Shiro's default session management does not work in a cluster environment. Shiro does have a cluster management server, but it is not implemented in this project. In it's place, the database will run a scheduled event to purge old sessions from the blocklyprop.sessions table.