### PR TITLE
Set min BP Client to v0.7.0 and improved port refresh and data throughput

### DIFF
--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -612,15 +612,17 @@ function graphing_console() {
 check_com_ports = function () {
     if (client_use_type !== 'ws') {
         if (client_url !== undefined) {
-            $.get(client_url + "ports.json", function (data) {
-                if ((client_version >= minEnc64Ver) && (typeof(data) == 'object')) {
+            if (client_version >= minEnc64Ver) {
+                // Client is >= minimum base64-encoded version
+                $.get(client_url + "ports.json", function (data) {
                     set_port_list(data);
-                } else {
+                }).fail(function () {
                     set_port_list([]);
-                }    
-            }).fail(function () {
+                });
+            } else {
+                // else always keep port list clear
                 set_port_list([]);
-            });
+            }    
         }
     }
 };
@@ -628,7 +630,7 @@ check_com_ports = function () {
 set_port_list = function (data) {
     var selected_port = $("#comPort").val();
     $("#comPort").empty();
-    if (data.length > 0) {
+    if (typeof(data) == 'object') {
         data.forEach(function (port) {
             $("#comPort").append($('<option>', {
                 text: port

--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -612,36 +612,37 @@ function graphing_console() {
 check_com_ports = function () {
     if (client_use_type !== 'ws') {
         if (client_url !== undefined) {
-            var selected_port = $("#comPort").val();
             $.get(client_url + "ports.json", function (data) {
-                if (client_version >= minEnc64Ver) {
-                    $("#comPort").empty();
-                    data.forEach(function (port) {
-                        $("#comPort").append($('<option>', {
-                            text: port
-                        }));
-                    });
-                    select_com_port(selected_port);
-                    client_available = true;
+                if ((client_version >= minEnc64Ver) && (typeof(data) == 'object')) {
+                    set_port_list(data);
                 } else {
-                    $("#comPort").empty();
-                    $("#comPort").append($('<option>', {
-                        text: 'Searching...'
-                    }));
-                    select_com_port(selected_port);
-                    client_available = false;
+                    set_port_list([]);
                 }    
             }).fail(function () {
-                $("#comPort").empty();
-                $("#comPort").append($('<option>', {
-                    text: 'Searching...'
-                }));
-                select_com_port(selected_port);
-                client_available = false;
+                set_port_list([]);
             });
         }
     }
 };
+
+set_port_list = function (data) {
+    var selected_port = $("#comPort").val();
+    $("#comPort").empty();
+    if (data.length > 0) {
+        data.forEach(function (port) {
+            $("#comPort").append($('<option>', {
+                text: port
+            }));
+        });
+        client_available = true;
+    } else {
+        client_available = false;
+        $("#comPort").append($('<option>', {
+            text: 'Searching...'
+        }));
+    };
+    select_com_port(selected_port);
+}
 
 select_com_port = function (com_port) {
     if (com_port !== null) {

--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -63,8 +63,8 @@ var graph_data = {
     ]
 };
 
+// Minimum BP Client/Launcher version accepted
 const minEnc64Ver = version_as_number('0.7.0');
-
 
 /**
  * Switch the visible pane when a tab is clicked.
@@ -348,8 +348,7 @@ function serial_console() {
             };
 
             connection.onmessage = function (e) {
-                var c_buf = (client_version >= minEnc64Ver) ? atob(e.data) : e.data;
-                //term.write(e.data);
+                var c_buf = atob(e.data);
                 if(connStrYet) {
                     displayInTerm(c_buf);
                 } else {
@@ -615,14 +614,23 @@ check_com_ports = function () {
         if (client_url !== undefined) {
             var selected_port = $("#comPort").val();
             $.get(client_url + "ports.json", function (data) {
-                $("#comPort").empty();
-                data.forEach(function (port) {
+                if (client_version >= minEnc64Ver) {
+                    $("#comPort").empty();
+                    data.forEach(function (port) {
+                        $("#comPort").append($('<option>', {
+                            text: port
+                        }));
+                    });
+                    select_com_port(selected_port);
+                    client_available = true;
+                } else {
+                    $("#comPort").empty();
                     $("#comPort").append($('<option>', {
-                        text: port
+                        text: 'Searching...'
                     }));
-                });
-                select_com_port(selected_port);
-                client_available = true;
+                    select_com_port(selected_port);
+                    client_available = false;
+                }    
             }).fail(function () {
                 $("#comPort").empty();
                 $("#comPort").append($('<option>', {

--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -197,7 +197,7 @@ function cloudCompile(text, action, successHandler) {
         alert("You can't compile an empty project");
     } else {
         $("#compile-dialog-title").text(text);
-        $("#compile-console").val('');
+        $("#compile-console").val('Compile...');
         $('#compile-dialog').modal('show');
 
 
@@ -230,10 +230,10 @@ function cloudCompile(text, action, successHandler) {
                     loadWaitMsg = '\nLoading program on the Propeller - Please Wait...\n';
                 }
                 if (data.success) {
-                    $("#compile-console").val(data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
+                    $("#compile-console").val($("#compile-console").val() + data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
                     successHandler(data, terminalNeeded);
                 } else {
-                    $("#compile-console").val(data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
+                    $("#compile-console").val($("#compile-console").val() + data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
                 }
             }
         }).fail(function (data) {

--- a/src/main/webapp/cdn/blocklyc.js
+++ b/src/main/webapp/cdn/blocklyc.js
@@ -63,6 +63,8 @@ var graph_data = {
     ]
 };
 
+const minEnc64Ver = version_as_number('0.7.0');
+
 
 /**
  * Switch the visible pane when a tab is clicked.
@@ -346,17 +348,12 @@ function serial_console() {
             };
 
             connection.onmessage = function (e) {
-                var c_buf;
-                if (version_as_number('0.7.0') > client_version) {
-                    c_buf = e.data;
-                } else {
-                    c_buf = atob(e.data);
-                }
+                var c_buf = (client_version >= minEnc64Ver) ? atob(e.data) : e.data;
                 //term.write(e.data);
                 if(connStrYet) {
-                    displayInTerm(e.data);
+                    displayInTerm(c_buf);
                 } else {
-                    connString += e.data;
+                    connString += c_buf;
                     if (connString.indexOf(baudrate.toString(10)) > -1) {
                         connStrYet = true;
                         document.getElementById('serial-conn-info').innerHTML = connString.trim();

--- a/src/main/webapp/cdn/blocklypropclient.js
+++ b/src/main/webapp/cdn/blocklypropclient.js
@@ -13,8 +13,8 @@ var client_version = 0;
 var client_domain_name = "localhost";
 var client_domain_port = 6009;
 
-var client_min_version = 0.2;
-var client_baud_rate_min_version = 0.4;
+var client_min_version = "0.7.0";
+var client_baud_rate_min_version = "0.4.0";
 
 var client_use_type = 'none';
 var client_ws_connection = null;
@@ -75,7 +75,7 @@ check_client = function () {
                 if (!data.server || data.server !== 'BlocklyPropHTTP') {
                     // wrong server
                 } else if (client_version < version_as_number(client_min_version)) {
-                    bootbox.alert("This now requires at least version " + client_min_version + " of BlocklyPropClient.");
+                    bootbox.alert("This system now requires at least version " + client_min_version + " of BlocklyPropClient- yours is: " + data.version);
                 }
 
                 if (version_as_number(data.version) >= version_as_number(client_baud_rate_min_version)) {
@@ -245,7 +245,7 @@ function establish_socket() {
                 console.log("Websocket client found - version " + ws_msg.version);
 
                 if (version_as_number(ws_msg.version) < version_as_number(client_min_version)) {
-                    bootbox.alert("This now requires at least version " + client_min_version + " of BlocklyPropClient.");
+                    bootbox.alert("This system now requires at least version " + client_min_version + " of BlocklyPropClient- yours is: " + ws_msg.version);
                 }
                 if (version_as_number(ws_msg.version) >= version_as_number(client_baud_rate_min_version)) {
                     baud_rate_compatible = true;

--- a/src/main/webapp/cdn/propterm.js
+++ b/src/main/webapp/cdn/propterm.js
@@ -26,6 +26,7 @@ var updateTermInterval = null;
 var bufferAlert = false;
 var scrollerTimeout = null;
 
+
 $(document).ready(function () {
 
     fontSize = $('#serial_console').css('font-size');
@@ -51,7 +52,11 @@ $(document).ready(function () {
         if (keycode === 8 || keycode === 13) {
 
             if (active_connection !== null && active_connection !== 'simulated' && active_connection !== 'websocket') {
-                active_connection.send(String.fromCharCode(keycode));
+                if (client_version >= minEnc64Ver) {
+                    active_connection.send(btoa(String.fromCharCode(keycode)));
+                } else {
+                    active_connection.send(String.fromCharCode(keycode));
+                }
                 if (trap_echos) {
                     echo_trap.push(keycode);
                 }
@@ -80,7 +85,11 @@ $(document).ready(function () {
         var charcode = e.charCode;
 
         if (active_connection !== null && active_connection !== 'simulated' && active_connection !== 'websocket') {
-            active_connection.send(String.fromCharCode(charcode));
+            if (client_version >= minEnc64Ver) {
+                active_connection.send(btoa(String.fromCharCode(charcode)));
+            } else {
+                active_connection.send(String.fromCharCode(charcode));
+            }
             if (trap_echos) {
                 echo_trap.push(charcode);
             }


### PR DESCRIPTION
- Warns users if they are using BP Clients older than v0.7.0
- Does not allow downloads with BP Clients older than v0.7.0
- Optimized port refresh process and enhanced to prevent visual refresh delays and un-selection
- Added 'no device detected' message.

**Merge #1288 first.**