### PR TITLE
Refactor to include the database reference in the table DDL

### DIFF
--- a/db-updates/0000-admin.sql
+++ b/db-updates/0000-admin.sql
@@ -16,10 +16,12 @@
 //              change was recorded.
 //--------------------------------------------------------------
 */
-CREATE TABLE if not exists `admin` (
+CREATE TABLE if not exists blocklyprop.admin (
   `id` bigint(20) PRIMARY KEY NOT NULL AUTO_INCREMENT,
   `db_version` int NOT NULL,
   `db_script` varchar(255) NOT NULL,
   `notes` varchar(255),
   `last_change_date` DATETIME NOT NULL DEFAULT NOW()
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;

--- a/db-updates/0001-initial.sql
+++ b/db-updates/0001-initial.sql
@@ -1,27 +1,9 @@
--- MySQL dump 10.13  Distrib 5.6.24, for Win64 (x86_64)
---
--- Host: localhost    Database: blocklyprop
--- ------------------------------------------------------
--- Server version	5.6.26-log
-
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
 -- Table structure for table `project`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `project` (
+CREATE TABLE IF NOT EXISTS blocklyprop.project (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `id_user` bigint(20) NOT NULL,
   `id_clouduser` bigint(20) NOT NULL,
@@ -36,57 +18,51 @@ CREATE TABLE if not exists `project` (
   `modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `based_on` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `project_tag`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `project_tag` (
+CREATE TABLE IF NOT EXISTS blocklyprop.project_tag (
   `id_project` bigint(20) NOT NULL,
   `id_tag` bigint(20) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `sec_role`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `sec_role` (
+CREATE TABLE IF NOT EXISTS blocklyprop.sec_role (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_UNIQUE` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `sec_user_role`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `sec_user_role` (
+CREATE TABLE IF NOT EXISTS blocklyprop.sec_user_role (
   `id_user` bigint(20) NOT NULL,
   `id_role` bigint(20) NOT NULL,
   UNIQUE KEY `UNIQUE_user_role` (`id_user`,`id_role`),
   KEY `FK_USER_ROLE_ROLE_idx` (`id_role`),
   CONSTRAINT `FK_USER_ROLE_ROLE` FOREIGN KEY (`id_role`) REFERENCES `sec_role` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `session`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `session` (
+CREATE TABLE IF NOT EXISTS blocklyprop.session (
   `idsession` varchar(255) NOT NULL,
   `startTimestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `lastAccessTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -94,44 +70,31 @@ CREATE TABLE if not exists `session` (
   `host` varchar(255) DEFAULT NULL,
   `attributes` mediumblob,
   PRIMARY KEY (`idsession`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8;
+
 
 --
 -- Table structure for table `tag`
 --
 
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `tag` (
+CREATE TABLE IF NOT EXISTS blocklyprop.tag (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_UNIQUE` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8;
+
 
 --
 -- Table structure for table `user`
 --
-
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE if not exists `user` (
+CREATE TABLE IF NOT EXISTS blocklyprop.user (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `idCloudSession` bigint(20) NOT NULL,
   `screenname` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
-
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on 2015-09-27 22:51:01
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;

--- a/db-updates/0002-add_share-key.sql
+++ b/db-updates/0002-add_share-key.sql
@@ -1,11 +1,15 @@
-CREATE TABLE if not exists project_sharing
-(
-    id BIGINT(20) PRIMARY KEY NOT NULL,
-    id_project BIGINT(20) NOT NULL,
-    sharekey VARCHAR(255) NOT NULL,
-    expires BIT(1) DEFAULT b'0',
-    exprire_date DATETIME,
-    CONSTRAINT project_sharing_project_id_fk FOREIGN KEY (id_project) REFERENCES project (id),
-    UNIQUE INDEX project_sharing_id_project_sharekey_uindex (id_project, sharekey),
-    INDEX project_sharing_sharekey_index (sharekey)
-);
+/*
+ * Create project sharing table
+ */
+
+CREATE TABLE IF NOT EXISTS blocklyprop.project_sharing (
+  id BIGINT(20) PRIMARY KEY NOT NULL,
+  id_project BIGINT(20) NOT NULL,
+  sharekey VARCHAR(255) NOT NULL,
+  expires BIT(1) DEFAULT b'0',
+  exprire_date DATETIME,
+  CONSTRAINT project_sharing_project_id_fk FOREIGN KEY (id_project) REFERENCES project (id),
+  UNIQUE INDEX project_sharing_id_project_sharekey_uindex (id_project, sharekey),
+  INDEX project_sharing_sharekey_index (sharekey)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8;

--- a/db-updates/0003-rich-text-editor.sql
+++ b/db-updates/0003-rich-text-editor.sql
@@ -1,1 +1,5 @@
-ALTER TABLE project ADD description_html LONGTEXT NULL AFTER description;
+/*
+ *  Add a description field to the project that supports HTML
+ */
+ALTER TABLE project
+  ADD description_html LONGTEXT NULL AFTER description;

--- a/db-updates/0004-friends.sql
+++ b/db-updates/0004-friends.sql
@@ -1,5 +1,8 @@
-CREATE TABLE friend_request
-(
+/*
+ * Add tables for the Friends feature
+ */
+
+CREATE TABLE IF NOT EXISTS blocklyprop.friend_request (
     id BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
     idRequestUser BIGINT NOT NULL,
     idRequestedUser BIGINT NOT NULL,
@@ -9,11 +12,16 @@ CREATE TABLE friend_request
     refused BIT DEFAULT 0 NOT NULL,
     CONSTRAINT friend_request_request_user_id_fk FOREIGN KEY (idRequestUser) REFERENCES user (id),
     CONSTRAINT friend_request_requested_user_id_fk FOREIGN KEY (idRequestedUser) REFERENCES user (id)
-);
-CREATE UNIQUE INDEX friend_request_idRequestUser_idRequestedUser_uindex ON friend_request (idRequestUser, idRequestedUser);
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;
 
-CREATE TABLE friend_request_email
-(
+
+CREATE UNIQUE INDEX friend_request_idRequestUser_idRequestedUser_uindex
+  ON blocklyprop.friend_request (idRequestUser, idRequestedUser);
+
+
+CREATE TABLE IF NOT EXISTS blocklyprop.friend_request_email (
     id BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
     idRequestUser BIGINT NOT NULL,
     email BIGINT NOT NULL,
@@ -23,11 +31,14 @@ CREATE TABLE friend_request_email
     request_last_sent DATETIME DEFAULT now(),
     refused BIT DEFAULT 0 NOT NULL,
     CONSTRAINT friend_request_email_request_user_id_fk FOREIGN KEY (idRequestUser) REFERENCES user (id)
-);
-CREATE UNIQUE INDEX friend_request_email_idRequestUser_idRequestedUser_uindex ON friend_request_email (idRequestUser, email);
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;
 
-CREATE TABLE friend
-(
+CREATE UNIQUE INDEX friend_request_email_idRequestUser_idRequestedUser_uindex
+  ON blocklyprop.friend_request_email (idRequestUser, email);
+
+CREATE TABLE IF NOT EXISTS blocklyprop.friend (
     id BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
     idRequestUser BIGINT NOT NULL,
     idRequestedUser BIGINT NOT NULL,
@@ -37,5 +48,9 @@ CREATE TABLE friend
     request_last_sent DATETIME DEFAULT now(),
     CONSTRAINT friend_request_user_id_fk FOREIGN KEY (idRequestUser) REFERENCES user (id),
     CONSTRAINT friend_requested_user_id_fk FOREIGN KEY (idRequestedUser) REFERENCES user (id)
-);
-CREATE UNIQUE INDEX friend_idRequestUser_idRequestedUser_uindex ON friend (idRequestUser, idRequestedUser);
+) ENGINE=InnoDB
+  AUTO_INCREMENT=0
+  DEFAULT CHARSET=utf8;
+
+CREATE UNIQUE INDEX friend_idRequestUser_idRequestedUser_uindex
+  ON blocklyprop.friend (idRequestUser, idRequestedUser);

--- a/db-updates/0005-fix_share-key_autoincrement.sql
+++ b/db-updates/0005-fix_share-key_autoincrement.sql
@@ -1,1 +1,6 @@
-ALTER TABLE project_sharing MODIFY id BIGINT(20) NOT NULL AUTO_INCREMENT;
+/*
+ *  Correct issue with project shaing id not incrementing
+ */
+
+ALTER TABLE blocklyprop.project_sharing MODIFY id BIGINT(20) NOT NULL AUTO_INCREMENT;
+


### PR DESCRIPTION
Statements could be inadvertently executed against the wrong database.