### PR TITLE
Correct issue with account confirmation textile file

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -28,7 +28,7 @@ footer.clientdownloadlink = BlocklyProp-client
 # Application version numbers.
 application.major = 0
 application.minor = 99
-application.build = 426
+application.build = 427
 
 html.content_missing = Content missing
 

--- a/src/main/resources/documents/confirm/confirmed.textile
+++ b/src/main/resources/documents/confirm/confirmed.textile
@@ -2,4 +2,4 @@ h3. Congratulations!
 
 Your account has been activated. You are ready to build your own projects. 
 
-Click here to return to home page":/blockly/index
+Click "here":/blockly/index to return to home page


### PR DESCRIPTION
Fixes issue #1351 
The link was missing a double quote character.
Bump up the build number.
