### PR TITLE
Miscellaneous updates to code

### DIFF
--- a/src/main/resources/documents/index.textile
+++ b/src/main/resources/documents/index.textile
@@ -1,4 +1,5 @@
- <div class="jumbotron">
+<!-- Deprecated. Replaced with inline code --> 
+<div class="jumbotron">
 
  <div class="logo">
 

--- a/src/main/webapp/WEB-INF/includes/pageparts/footer.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/footer.jsp
@@ -15,7 +15,7 @@
             <div>
                 <ul class="nav navbar-nav">
                     <li><a href="<url:getUrl url="/public/license"/>"><fmt:message key="footer.licenselink" /></a></li>
-                    <li><a href=https://github.com/parallaxinc/BlocklyProp/releases" target="_blank"><fmt:message key="footer.changelog" /></a></li>
+                    <li><a href="https://github.com/parallaxinc/BlocklyProp/releases" target="_blank"><fmt:message key="footer.changelog" /></a></li>
                     <li><a href="<url:getUrl url="/public/libraries"/>"><fmt:message key="footer.librarieslink" /></a></li>
                     <li><a href="<url:getUrl url="/public/clientdownload"/>"><fmt:message key="footer.clientdownloadlink" /></a></li>
                 </ul>

--- a/src/main/webapp/WEB-INF/includes/pageparts/head/basic.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/head/basic.jsp
@@ -1,6 +1,6 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!--basic.jsp-->
 <meta name="application-name" content="BlocklyProp"/>
 <meta name="msapplication-TileColor" content="#FFFFFF" />
 <meta name="msapplication-TileImage" content="<url:getCdnUrl url="/images/mstile-144x144.png" />" />

--- a/src/main/webapp/WEB-INF/servlet/clientdownload.jsp
+++ b/src/main/webapp/WEB-INF/servlet/clientdownload.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="base" content="<url:getUrl url="/"/>">

--- a/src/main/webapp/WEB-INF/servlet/html.jsp
+++ b/src/main/webapp/WEB-INF/servlet/html.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="base" content="<url:getUrl url="/"/>">

--- a/src/main/webapp/WEB-INF/servlet/index.jsp
+++ b/src/main/webapp/WEB-INF/servlet/index.jsp
@@ -3,13 +3,12 @@
     Created on : 24-mei-2015, 18:41:02
     Author     : Michel
 --%>
-
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
-        <meta name="application-name" content="&nbsp;"/>
+        <meta name="application-name" content="BlocklyProp"/>
         <meta name="msapplication-TileColor" content="#FFFFFF" />
         <meta name="msapplication-TileImage" content="<url:getCdnUrl url="/images/mstile-144x144.png" />" />
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="57x57" href="<url:getCdnUrl url="/images/apple-touch-icon-57x57.png"/>" />
@@ -32,15 +31,14 @@
         <%@ include file="/WEB-INF/includes/pageparts/menu.jsp"%>
 
         <div class="container">
-                <%
-                String html = (String) request.getAttribute("html");
-                if (html != null) {
-            %>
-            <%= html%>
-            <% } else {%>
-            <h2><fmt:message key="html.content_missing" /></h2>
-            <% }%>
-
+            <!-- Splash image -->
+            <div class="jumbotron">
+                <div class="logo">
+                    <h1 id="BlocklyProp">BlocklyProp</h1>
+                </div>
+                <p><strong>Blockly for Propeller Multicore:</strong>Making amazing projects and learning to code just became easier</p>
+                <p><img class="cdn full-width" border="0" src="<url:getCdnUrl url="/images/home-banner.png"/>"></p>
+            </div>
             <h2 class="pad-latest-projects"><fmt:message key="home.latest_projects.title" /></h2>
             <hr>
             <ul class="latest-projects"></ul>

--- a/src/main/webapp/WEB-INF/servlet/profile/profile-oauth.jsp
+++ b/src/main/webapp/WEB-INF/servlet/profile/profile-oauth.jsp
@@ -6,10 +6,10 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
-        <meta name="application-name" content="&nbsp;"/>
+        <meta name="application-name" content="BlocklyProp"/>
         <meta name="msapplication-TileColor" content="#FFFFFF" />
         <meta name="msapplication-TileImage" content="<url:getCdnUrl url="/images/mstile-144x144.png" />" />
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="57x57" href="<url:getCdnUrl url="/images/apple-touch-icon-57x57.png"/>" />

--- a/src/main/webapp/WEB-INF/servlet/profile/profile.jsp
+++ b/src/main/webapp/WEB-INF/servlet/profile/profile.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="application-name" content="&nbsp;"/>

--- a/src/main/webapp/WEB-INF/servlet/project/not-authorized.jsp
+++ b/src/main/webapp/WEB-INF/servlet/project/not-authorized.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="base" content="<url:getUrl url="/"/>">

--- a/src/main/webapp/WEB-INF/servlet/project/not-found.jsp
+++ b/src/main/webapp/WEB-INF/servlet/project/not-found.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="base" content="<url:getUrl url="/"/>">

--- a/src/main/webapp/WEB-INF/servlet/project/project-link-c.jsp
+++ b/src/main/webapp/WEB-INF/servlet/project/project-link-c.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html><!-- manifest=node.manifest> -->
     <head>
         <meta name="application-name" content="&nbsp;"/>

--- a/src/main/webapp/WEB-INF/servlet/project/project-link-spin.jsp
+++ b/src/main/webapp/WEB-INF/servlet/project/project-link-spin.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html><!-- manifest=node.manifest> -->
     <head>
         <meta name="application-name" content="&nbsp;"/>

--- a/src/main/webapp/WEB-INF/servlet/public-profile.jsp
+++ b/src/main/webapp/WEB-INF/servlet/public-profile.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <%@ include file="/WEB-INF/includes/pageparts/head/basic.jsp"%>

--- a/src/main/webapp/WEB-INF/servlet/register/register.jsp
+++ b/src/main/webapp/WEB-INF/servlet/register/register.jsp
@@ -7,7 +7,7 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-
+<!DOCTYPE html>
 <html>
     <head>
         <%@ include file="/WEB-INF/includes/pageparts/head/basic.jsp"%>

--- a/src/main/webapp/WEB-INF/servlet/register/registered.jsp
+++ b/src/main/webapp/WEB-INF/servlet/register/registered.jsp
@@ -6,7 +6,7 @@
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-
+<!DOCTYPE html>
 <html>
     <head>
         <%@ include file="/WEB-INF/includes/pageparts/head/basic.jsp"%>

--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -10,7 +10,7 @@
 <!-- Support for experimental blocks in Demo builds  -->
 <!-- See developer notes to use this feature         -->
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -104,7 +104,7 @@
                                 </div>
                                 <div style="display:inline;">
                                     <div style="width:100%; ">
-                                        <div style="display:inline; padding-left: 10px; line-height: 30px;" class="auth-true" displayas="inline">
+                                        <div style="display:inline; padding-left: 10px; line-height: 30px;" class="auth-true">
                                             <span id="client-searching" class="bp-client-warning">
                                                 <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal" href="#">
                                                     <svg preserveAspectRatio="xMinYMin" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M7,8 L8,8 8,11 8,11 7,11 Z" style="stroke-width:1px;stroke:#8a6d3b;fill:none;"/><circle cx="7.5" cy="7.5" r="6" style="stroke-width:1.3px;stroke:#8a6d3b;fill:none;"/><circle cx="7.5" cy="5" r="1.25" style="stroke-width:0;fill:#8a6d3b;"/></svg>

--- a/src/main/webapp/projectcreate.jsp
+++ b/src/main/webapp/projectcreate.jsp
@@ -9,7 +9,7 @@
 
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
 <c:set var="copparestricted" scope="page" value="${properties:copparestricted()}" />
-
+<!DOCTYPE html>
 <html>
     <!-- manifest=node.manifest> -->
     <head>


### PR DESCRIPTION
Minor fixes to correct various HTML errors.

Replaced the Textile-driven home page splash image with the equivalent inline HTML code. The Textile version of the code was embedding and extra set of <html></html> tags in the document.

Added a <!DOCTYPE html> declaration to all the files that were creating html pages without a doctype definition.