### PR TITLE
Remove DOCTYPE declaration to correct 300px high editor pallet.

### DIFF
--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -10,7 +10,7 @@
 <!-- Support for experimental blocks in Demo builds  -->
 <!-- See developer notes to use this feature         -->
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
-<!DOCTYPE html>
+
 <html>
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
This is really weird. If the <!DOCTYPE html> is inserted at the top of the HTML document, the editor pallet renders to about 300 pixels tall. Remove the declaration, and the editor pallet goes back to normal dimensions. 

@MatzElectronics This file has a ton of potential HTML errors, mostly related to unknown attributes. I'm not sure if it's related, but something doesn't like HTML5 in this page.