### PR TITLE
Disable all calls to user.changeScreenName. 

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/UserDao.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/UserDao.java
@@ -47,6 +47,7 @@ public interface UserDao {
 
     Long getUserIdForCloudSessionUserId(Long id);
 
+    @Deprecated
     public void updateScreenname(Long idUser, String screenname);
 
 }

--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/UserDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/UserDaoImpl.java
@@ -98,24 +98,28 @@ public class UserDaoImpl implements UserDao {
             return null;
         }
         
-        UserRecord record = create.insertInto(
+        UserRecord record = create.insertInto( 
                 Tables.USER, 
-                Tables.USER.IDCLOUDSESSION, Tables.USER.SCREENNAME)
+                Tables.USER.IDCLOUDSESSION,
+                Tables.USER.SCREENNAME)
                 .values(idCloudSession, screenName)
                 .returning()
                 .fetchOne();
 
+        // Set the User role for this new account
         if (record != null && record.getId() != null && record.getId() > 0) {
             Set<Role> roles = new HashSet<>();
             roles.add(Role.USER);
+            
+            // Update the Roles table
             try {
                 setRoles(record.getId(), roles);
             } catch (UnauthorizedException ue) {
                 // Can be dismissed because of hard coded user role
                 // Print exception in case anything should change
                 LOG.error("Creating a user should have no problem with creating its role (only USER role)", ue);
+                return null;
             }
-
         }
 
         return record;
@@ -231,6 +235,7 @@ public class UserDaoImpl implements UserDao {
     }
 
     @Override
+    @Deprecated
     public void updateScreenname(Long idUser, String screenname) {
         LOG.info("Attempting to update screen name for user: {} ", idUser);
         

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/ProfileServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/ProfileServlet.java
@@ -84,13 +84,20 @@ public class ProfileServlet extends HttpServlet {
     }
 
     //@Override
+    @Deprecated
     protected void oldDoPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
             log.info("Updating user info");
             User user = cloudSessionUserService.getUser(BlocklyPropSecurityUtils.getUserInfo().getId());
             if (user != null) {
                 SecurityServiceImpl.getSessionData().setUser(user);
-                userDao.updateScreenname(BlocklyPropSecurityUtils.getCurrentUserId(), user.getScreenname());
+                
+                /*
+                 * User screen name updates are disabled until the user profile page
+                 * is capable of supporting this feature
+                */
+//                userDao.updateScreenname(BlocklyPropSecurityUtils.getCurrentUserId(), user.getScreenname());
+
             }
         } catch (UnknownUserIdException uuie) {
             log.error("Unknown user", uuie);
@@ -168,6 +175,7 @@ public class ProfileServlet extends HttpServlet {
         req.setAttribute("email", user.getEmail());
         req.setAttribute("screenname", user.getScreenname());
         String screenname = req.getParameter("screenname");
+
         if (Strings.isNullOrEmpty(screenname)) {
             req.setAttribute("base-error", "Missing fields");
             req.getRequestDispatcher("WEB-INF/servlet/profile/profile.jsp").forward(req, resp);
@@ -176,7 +184,13 @@ public class ProfileServlet extends HttpServlet {
                 user = cloudSessionUserService.changeUserInfo(BlocklyPropSecurityUtils.getCurrentSessionUserId(), screenname);
                 if (user != null) {
                     SecurityServiceImpl.getSessionData().setUser(user);
-                    userDao.updateScreenname(BlocklyPropSecurityUtils.getCurrentUserId(), user.getScreenname());
+                    
+                    /*
+                     * Not allowing changed to the screen name until the user profile
+                     * page is capble of supporting this feature
+                    */
+//                    userDao.updateScreenname(BlocklyPropSecurityUtils.getCurrentUserId(), user.getScreenname());
+
                     req.setAttribute("base-success", "Info changed");
                     req.setAttribute("screenname", user.getScreenname());
                     req.getRequestDispatcher("WEB-INF/servlet/profile/profile.jsp").forward(req, resp);

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/RegisterServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/RegisterServlet.java
@@ -114,8 +114,8 @@ public class RegisterServlet extends HttpServlet {
         String sponsorEmail = Strings.emptyToNull(req.getParameter("sponsoremail"));
         String sponsorEmailType = Strings.emptyToNull(req.getParameter("sponsoremailtype"));
        
-        LOG.info("Raw screen name: {}", screenname);
-        LOG.info("Raw sponsor email address is: {}", sponsorEmail);
+        LOG.debug("Raw screen name: {}", screenname);
+        LOG.debug("Raw sponsor email address is: {}", sponsorEmail);
 
         // Clean up any possible null fields
         req.setAttribute("screenname", screenname == null ? "" : screenname);
@@ -126,14 +126,13 @@ public class RegisterServlet extends HttpServlet {
         req.setAttribute("sponsoremailtype", sponsorEmailType == null ? "0" : sponsorEmailType);
                 
         // Log a few things
-        LOG.info("Registering screen name: {}", screenname);
-        LOG.info("Registering email: {}", email);
-        LOG.info("Registering month: {}", birthMonth);
-        LOG.info("Registering year: {}", birthYear);
-        LOG.info("Registering sponsor email: {}", sponsorEmail);
-        LOG.info("Registering sponsor type selection: {}", sponsorEmailType);
-
-        LOG.info("Checking REQ Year setting: {}",req.getAttribute("bdmonth"));
+        LOG.debug("Registering screen name: {}", screenname);
+        LOG.debug("Registering email: {}", email);
+        LOG.debug("Registering month: {}", birthMonth);
+        LOG.debug("Registering year: {}", birthYear);
+        LOG.debug("Registering sponsor email: {}", sponsorEmail);
+        LOG.debug("Registering sponsor type selection: {}", sponsorEmailType);
+        LOG.debug("Checking REQ Year setting: {}",req.getAttribute("bdmonth"));
         
         Long idUser;
         


### PR DESCRIPTION
Once the account is created, there is no need to change the screen name until the user profile page is ready to go.

There is an issue where the user screen name in the blocklyprop.user table is updated incorrectly. While the root cause is still under investigation, the issue can be mitigated by preventing the screen name to be changed at all in the target table. This patch does exactly that.