### PR TITLE
add 'data-' to XML block list names

### DIFF
--- a/src/main/webapp/cdn/editor.js
+++ b/src/main/webapp/cdn/editor.js
@@ -609,7 +609,7 @@ function filterToolbox(profileName, peripherals) {
         }
 
         // Set the category's label
-        var catKey = toolboxEntry.attr('key');
+        var catKey = toolboxEntry.attr('data-key');
         if (catKey) {
             toolboxEntry.attr('name', toolbox_label[catKey]);
         }

--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -11,7 +11,7 @@
 <!-- See developer notes to use this feature         -->
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
 
-<!DOCTYPE html>
+
 <html>
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
Continuing to make HTML more valid.  Although the <!DOCTYPE html> tag is required, it appears to be incompatible with inline XML for some browsers.  Removing it and going back to doing some research to find the best way to support it.