### PR TITLE
Add code to detect a failed project load

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
@@ -61,7 +61,8 @@ public class ProjectSharingServiceImpl implements ProjectSharingService {
         List<ProjectSharingRecord> projectList = projectSharingDao.getSharingInfo(idProject);
         
         if (projectList == null | projectList.size() == 0) {
-            LOG.info("Project sharing record does not exist for project: {}", idProject);
+            LOG.info("Project sharing record does not exist for project: {}.", idProject);
+            LOG.info("Creating new project sharing link for project {}.", idProject);
             
             // Create a shared project record
             return projectSharingDao.shareProject(

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/ProjectLinkServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/ProjectLinkServlet.java
@@ -67,7 +67,7 @@ public class ProjectLinkServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
         
-        LOG.info("ProjectLinkServlet - Get()");
+        LOG.info("REST: /projectlink/");
         
         // Project ID
         String idProjectString = req.getParameter("id");
@@ -85,7 +85,7 @@ public class ProjectLinkServlet extends HttpServlet {
             req.getRequestDispatcher("/WEB-INF/servlet/project/not-found.jsp").forward(req, resp);
         }
         
-        LOG.info("ProjectLinkServlet - Get(" + idProject.toString() + ")");
+        LOG.info("Get project link for project {}.",idProject);
         
         // Retreive the project. Project meta data will be retruned if the project exists
         // and the project share key is known and active
@@ -93,7 +93,7 @@ public class ProjectLinkServlet extends HttpServlet {
         
         if (project == null) {
             // Project not found, or invalid share key
-            LOG.info("Unable to retrieve project");
+            LOG.info("Unable to retrieve parent project");
             req.getRequestDispatcher("/WEB-INF/servlet/project/not-found.jsp").forward(req, resp);
         } else {
             // Add project meta data to result object
@@ -167,10 +167,16 @@ public class ProjectLinkServlet extends HttpServlet {
             case "share":
                 // Make the project sharing record active.
                 ProjectSharingRecord projectSharingRecord = projectSharingService.shareProject(idProject);
+                if (projectSharingRecord == null) {
+                    LOG.error("Unable to activate a project sharing record for project {}.", idProject);
+                    resp.getWriter().write(createFailure("no-action").toString());
+                } else {
                 jsonObject.addProperty("success", true);
                 jsonObject.addProperty("share-key", projectSharingRecord.getSharekey());
                 resp.getWriter().write(jsonObject.toString());
+                }
                 break;
+
             case "revoke":
                 projectSharingService.revokeSharing(idProject);
                 jsonObject.addProperty("success", true);


### PR DESCRIPTION
Improve logging messages for the shared project link code.

It appears to be possible to fail to create a shared project link within the dao layer. This code will at least detect the condition and report it back to the client.