### PR TITLE
Set new shared project link records acive when created

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
@@ -73,11 +73,13 @@ public class ProjectSharingDaoImpl implements ProjectSharingDao {
                 .insertInto(Tables.PROJECT_SHARING)
                 .columns(
                         Tables.PROJECT_SHARING.ID_PROJECT, 
-                        Tables.PROJECT_SHARING.SHAREKEY
+                        Tables.PROJECT_SHARING.SHAREKEY,
+                        Tables.PROJECT_SHARING.ACTIVE
                 )
                 .values(
                         idProject, 
-                        shareKey
+                        shareKey,
+                        true
                 )
                 .returning()
                 .fetchOne();


### PR DESCRIPTION
This will mirror the state of the UI when the user clicks on the checkbox to activate the link. If the shared project record does not exist, we create a new one. However, because the UI shows the box as checked, we need to default the new record to active as well.