### PR TITLE
Add code to remove project sharing records linked to project

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/ProjectSharingDao.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/ProjectSharingDao.java
@@ -25,4 +25,6 @@ public interface ProjectSharingDao {
     // Set the active flag in an existing shared project record
     public ProjectSharingRecord activateProject(Long idProject);
 
+    // Remove a project sharing link record
+    public boolean deleteProjectSharingRecord(Long idProject);
 }

--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
@@ -162,4 +162,20 @@ public class ProjectSharingDaoImpl implements ProjectSharingDao {
         return project;
     }
 
+    /**
+     * Remove any project sharing records related to the specified project
+     * 
+     * @param idProject
+     * @return 
+     */
+    @Override
+    public boolean deleteProjectSharingRecord(Long idProject) {
+        LOG.info("Delete sharing record for project {}.", idProject);
+        
+        return create.deleteFrom(Tables.PROJECT_SHARING)
+                .where(Tables.PROJECT_SHARING.ID_PROJECT.equal(idProject))
+                .execute() > 0;
+
+    }
+
 }

--- a/src/main/java/com/parallax/server/blocklyprop/services/ProjectSharingService.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/ProjectSharingService.java
@@ -27,4 +27,7 @@ public interface ProjectSharingService {
     // Get a project project record only if the project id and shared key are equal
     ProjectRecord getSharedProject(Long idProject, String shareKey);
 
+    // Delete a project sharing record
+    public boolean deleteSharedProject(Long idProject);
+    
 }

--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectServiceImpl.java
@@ -232,9 +232,23 @@ public class ProjectServiceImpl implements ProjectService {
         return projectDao.cloneProject(idProject);
     }
 
+    
+    /**
+     * Delete a project
+     * 
+     * Remove the shared project link if one exists before removing the project.
+     * 
+     * @param idProject
+     * @return 
+     */
     @Override
     public boolean deleteProject(Long idProject) {
-        projectSharingService.revokeSharing(idProject);
+        
+        LOG.info("Deleting project {}", idProject);
+        
+        // Remove the project shared key if it exists.
+        projectSharingService.deleteSharedProject(idProject);
+
         return projectDao.deleteProject(idProject);
     }
 

--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
@@ -75,7 +75,12 @@ public class ProjectSharingServiceImpl implements ProjectSharingService {
         return projectSharingDao.activateProject(projectList.get(0).getIdProject());
     }
 
-    
+    /**
+     * Revoke the shared project ID
+     * 
+     * @param idProject
+     * @return 
+     */
     @Override
     public int revokeSharing(Long idProject) {
         LOG.info("Disabling shared link for project: {}", idProject);
@@ -120,6 +125,19 @@ public class ProjectSharingServiceImpl implements ProjectSharingService {
         
         // Unable to return the shared project
         return null;
+    }
+    
+    /**
+     * Delete the shared project link record
+     * 
+     * @param idProject
+     * @return 
+     */
+    @Override
+    public boolean deleteSharedProject(Long idProject) {
+        LOG.info("Deleting project share link for project {}", idProject);
+        
+        return projectSharingDao.deleteProjectSharingRecord(idProject);
     }
 
 }


### PR DESCRIPTION
A project cannot be deleted until the related project sharing link records have been removed.  Updated the shared project code to actually delete the record rather than simply revoking the link. This avoids the foreign key constraint error when an attempt is made to delete a project.

Reference issue #1487 
