### PR TITLE
Correct error in application version number in the 0.101 branch.

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -27,8 +27,8 @@ footer.clientdownloadlink = BlocklyProp-client
 
 # Application version numbers.
 application.major = 0
-application.minor = 100
-application.build = 438
+application.minor = 101
+application.build = 439
 
 html.content_missing = Content missing
 


### PR DESCRIPTION
Someone, perhaps me, fat-fingered the version number on a prior commit. This patch corrects the error.