### PR TITLE
Update file to support root level redirect

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context antiJARLocking="true" path="/blockly"/>
+<Context antiJARLocking="true" path="/" docBase="blockly"/>


### PR DESCRIPTION
The ROOT web site on a default tomcat installation contains a generic "Thanks for using Tomcat" message. The external build tools will replace that page with a redirect. This correct the context.xml file to support the same redirect.