### PR TITLE
Update revision number to 1.0.440 to build Demo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,20 +560,5 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-    
-        <!-- https://mvnrepository.com/artifact/org.netbeans.api/org-netbeans-modules-nbjunit -->
-    <!--    <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-netbeans-modules-nbjunit</artifactId>
-            <version>RELEASE801</version>
-        </dependency>
-    -->
-        <!-- https://mvnrepository.com/artifact/org.netbeans.api/org-netbeans-modules-jellytools-platform -->
-    <!--    <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-netbeans-modules-jellytools-platform</artifactId>
-            <version>RELEASE801</version>
-        </dependency>
-    -->
     </dependencies>
 </project>

--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -26,9 +26,9 @@ footer.librarieslink = External libraries
 footer.clientdownloadlink = BlocklyProp-client
 
 # Application version numbers.
-application.major = 0
-application.minor = 101
-application.build = 439
+application.major = 1
+application.minor = 0
+application.build = 440
 
 html.content_missing = Content missing
 


### PR DESCRIPTION
Correct an issue where the major and minor version number in the build was not matching the expected major/minor version number in the CI system. This caused the CI system to continue deploying the old 0.101 version to the Demo server.

Also removing unneeded dependencies in the application pom file.