### PR TITLE
Add EmailNotConfirmed exception where appropriate.

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/security/CloudSessionAuthenticationRealm.java
+++ b/src/main/java/com/parallax/server/blocklyprop/security/CloudSessionAuthenticationRealm.java
@@ -159,14 +159,20 @@ public class CloudSessionAuthenticationRealm extends AuthorizingRealm {
             return null;
         } catch (UnknownUserException ex) {
             LOG.info("Unknown user", ex);
+
         } catch (UserBlockedException ex) {
             LOG.info("Blocked user", ex);
+
         } catch (EmailNotConfirmedException ex) {
             LOG.info("Email not confirmed", ex);
+            throw new AuthenticationException("Email is unconfirmed");
+
         } catch (InsufficientBucketTokensException ibte) {
             LOG.info("Insufficient bucken tokens", ibte);
+
         } catch (NullPointerException npe) {
             LOG.warn("NullPointer", npe);
+
         } catch (Throwable t) {
             // This is a catchall exception handler that kicks the can back
             // to the caller

--- a/src/main/java/com/parallax/server/blocklyprop/services/SecurityService.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/SecurityService.java
@@ -39,7 +39,8 @@ public interface SecurityService {
                 UserBlockedException, 
                 EmailNotConfirmedException, 
                 InsufficientBucketTokensException, 
-                WrongAuthenticationSourceException;
+                WrongAuthenticationSourceException,
+                NullPointerException;
 
     Long register(
             String screenname, 

--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/SecurityServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/SecurityServiceImpl.java
@@ -351,7 +351,9 @@ public class SecurityServiceImpl implements SecurityService {
      * @throws UserBlockedException
      * @throws EmailNotConfirmedException
      * @throws InsufficientBucketTokensException
-     * @throws WrongAuthenticationSourceException 
+     * @throws WrongAuthenticationSourceException
+     * @throws NullPointerException
+     *
      */
     @Override
     public User authenticateLocalUser(String email, String password) throws 
@@ -359,7 +361,8 @@ public class SecurityServiceImpl implements SecurityService {
             UserBlockedException, 
             EmailNotConfirmedException, 
             InsufficientBucketTokensException, 
-            WrongAuthenticationSourceException {
+            WrongAuthenticationSourceException,
+            NullPointerException {
         
         try {
             LOG.info("Attempting to authenticate {}", email);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,7 +9,11 @@ Valid logging levels: TRACE, DEBUG, INFO, WARN and ERROR
 -->
 <configuration>
     <!-- Log file destinations are defined here -->
+    <!--
     <property name="APP_LOG_PATH" value="/var/log/tomcat7"/>
+    -->
+    <property name="APP_LOG_PATH" value="${catalina.home}/logs"/>
+
     <property name="APP_LOG_FILE_BASE" value="blockly-app"/>
     
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Reference issue #1445, add code to propagate the EmailNotConfirmed exception from the Cloud-Session server interface. Still need to update the UI to detect and enumerate this error.

Update logback config to use CatalinaHome/logs for logging.
