### PR TITLE
Remove redundant function call

### DIFF
--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -99,7 +99,7 @@
         --%>
     </head>
     
-    <body onload="blocklyReady();">
+    <body>
         <div id="editor">
             <table id="content_table">
                 <tr>


### PR DESCRIPTION
This is handled within jQuery's .ready() function instead.