### PR TITLE
Add surefire package now required by Jenkins CI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,5 +538,13 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.12.4</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
The Jenkins build process is reporting an error that indicates that a SureFire package is missing. 