### PR TITLE
Add surefire package now required by Jenkins CI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,5 +538,13 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.12.4</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
Jenkins is reporting this error:

```
16:04:11 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project BlocklyProp: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ? -> [Help 1]
```

Added the missing Surefire plugin to the project.