### PR TITLE
Add code to trap new Cloud Session exception.

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/rest/RestProfile.java
+++ b/src/main/java/com/parallax/server/blocklyprop/rest/RestProfile.java
@@ -20,6 +20,7 @@ import com.parallax.client.cloudsession.exceptions.ScreennameUsedException;
 import com.parallax.client.cloudsession.exceptions.ServerException;
 import com.parallax.client.cloudsession.exceptions.UnknownUserIdException;
 import com.parallax.client.cloudsession.exceptions.WrongAuthenticationSourceException;
+import com.parallax.client.cloudsession.exceptions.EmailNotConfirmedException;
 import com.parallax.client.cloudsession.objects.User;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -152,6 +153,10 @@ public class RestProfile {
                 LOG.warn("Trying to change password of non local user!");
                 result.addProperty("success", false);
                 result.addProperty("message", "server-error");
+                return Response.ok(result.toString()).build();
+            } catch (EmailNotConfirmedException pce) {
+                result.addProperty("success", false);
+                result.addProperty("message", "password-complexity");
                 return Response.ok(result.toString()).build();
             }
         }

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/PasswordResetServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/PasswordResetServlet.java
@@ -14,6 +14,7 @@ import com.parallax.client.cloudsession.exceptions.PasswordVerifyException;
 import com.parallax.client.cloudsession.exceptions.ServerException;
 import com.parallax.client.cloudsession.exceptions.UnknownUserException;
 import com.parallax.client.cloudsession.exceptions.WrongAuthenticationSourceException;
+import com.parallax.client.cloudsession.exceptions.EmailNotConfirmedException;
 import com.parallax.server.blocklyprop.enums.PasswordResetPage;
 import com.parallax.server.blocklyprop.utils.ServletUtils;
 import com.parallax.server.blocklyprop.utils.TextileReader;
@@ -97,6 +98,9 @@ public class PasswordResetServlet extends HttpServlet {
             } catch (WrongAuthenticationSourceException ex) {
                 LOG.warn("Trying to change password of non local user!");
                 req.setAttribute("server-error", "Server exception");
+                req.getRequestDispatcher("WEB-INF/servlet/password-reset/do-reset.jsp").forward(req, resp);
+            } catch (EmailNotConfirmedException pce) {
+                req.setAttribute("passwordComplexity", "Password is not complex enough");
                 req.getRequestDispatcher("WEB-INF/servlet/password-reset/do-reset.jsp").forward(req, resp);
             }
         }

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/ProfileServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/ProfileServlet.java
@@ -235,6 +235,10 @@ public class ProfileServlet extends HttpServlet {
                 LOG.warn("Trying to change password of non local user!");
                 req.setAttribute("base-error", "Server error");
                 req.getRequestDispatcher("WEB-INF/servlet/profile/profile.jsp").forward(req, resp);
+            } catch (EmailNotConfirmedException ex) {
+                LOG.warn("Trying to change password of non local user!");
+                req.setAttribute("base-error", "Server error");
+                req.getRequestDispatcher("WEB-INF/servlet/profile/profile.jsp").forward(req, resp);
             }
         }
     }

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/PublicProfileServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/PublicProfileServlet.java
@@ -11,6 +11,7 @@ import com.google.inject.Singleton;
 import com.parallax.client.cloudsession.CloudSessionUserService;
 import com.parallax.client.cloudsession.exceptions.ServerException;
 import com.parallax.client.cloudsession.exceptions.UnknownUserIdException;
+import com.parallax.client.cloudsession.exceptions.EmailNotConfirmedException;
 import com.parallax.server.blocklyprop.db.generated.tables.pojos.User;
 import com.parallax.server.blocklyprop.services.UserService;
 import com.parallax.server.blocklyprop.services.impl.SecurityServiceImpl;
@@ -84,6 +85,9 @@ public class PublicProfileServlet extends HttpServlet {
             req.setAttribute("screenname", cloudSessionUser.getScreenname());
             req.getRequestDispatcher("/WEB-INF/servlet/public-profile.jsp").forward(req, resp);
         } catch (UnknownUserIdException ex) {
+            LOG.info("User not known in cloud-session");
+            resp.sendError(404);
+        } catch (EmailNotConfirmedException ex) {
             LOG.info("User not known in cloud-session");
             resp.sendError(404);
         } catch (ServerException ex) {


### PR DESCRIPTION
Add code to trap a new EmailNotConfirmed exception available from the Cloud Session server. This exception is generated when the user attempts to login or perform a password reset with an email address that has not yet been confirmed.