### PR TITLE
Correct session timeout stack dump

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/servlets/TextileIndexServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/TextileIndexServlet.java
@@ -13,6 +13,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.shiro.session.UnknownSessionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  *
@@ -20,14 +24,29 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Singleton
 public class TextileIndexServlet extends HttpServlet {
+            
+    /**
+     * Application logging facility
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(TextileIndexServlet.class);
 
     private final TextileReader textileFileReader = new TextileReader();
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String html = textileFileReader.readFile("index", ServletUtils.getLocale(req), req.isSecure());
-        req.setAttribute("html", html);
-        req.getRequestDispatcher("/WEB-INF/servlet/index.jsp").forward(req, resp);
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        
+        try {
+            String html = textileFileReader.readFile("index", ServletUtils.getLocale(req), req.isSecure());
+            req.setAttribute("html", html);
+            req.getRequestDispatcher("/WEB-INF/servlet/index.jsp").forward(req, resp);
+        }
+        catch (UnknownSessionException ex) {
+            // Redrect the session back to the home page.
+            LOG.error("Session has expired. Request was for: {}", req.getRequestURI());
+            resp.flushBuffer();
+            req.getRequestDispatcher("/WEB-INF/servlet/index.jsp").forward(req, resp);
+        }
     }
 
 }


### PR DESCRIPTION
This PR addresses issue #1556. Refactor code to trap the UnknownSessionException and return the client browser to the home page as an unauthenticated user. 