### PR TITLE
Rotate log files at 10MB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <!-- jOOQ version 3.7 and above requires Java 1.8.x JDK -->
         <jooq-version>3.7.4</jooq-version>
-
+        <gson.version>2.8.5</gson.version>
         <shiro-version>1.3.2</shiro-version>
         <metrics-version>3.1.0</metrics-version>
         <jersey.version>1.19</jersey.version>
@@ -353,8 +353,23 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+
 
         <!-- -->
         <dependency>
@@ -505,7 +520,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.3.1</version>
+            <version>${gson.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,22 +11,43 @@ Valid logging levels: TRACE, DEBUG, INFO, WARN and ERROR
     <!-- Log file destinations are defined here -->
     <property name="APP_LOG_PATH" value="${catalina.home}/logs"/>
     <property name="APP_LOG_FILE_BASE" value="blockly-app"/>
-    
+
+    <!--    
     <appender name="file" class="ch.qos.logback.core.FileAppender">
         <file>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}.log</file>
         <encoder>
-            <!--
-            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-            -->
             <pattern>%date %level [%file:%line] %msg%n</pattern>
         </encoder>
     </appender>
+-->    
+    <appender name="FIX_WINDOW_BASED_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+	    <fileNamePattern>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}%i.log</fileNamePattern>
+	    <minIndex>1</minIndex>
+	    <maxIndex>20</maxIndex>
+	</rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>10MB</maxFileSize>
+	</triggeringPolicy>
+     
+	<encoder>
+            <pattern>%date %level [%file:%line] %msg%n</pattern>
+	</encoder>
+    </appender>   
+
+    <logger name="fixWindowBased" level="INFO">
+        <appender-ref ref="FIX_WINDOW_BASED_FILE" />
+        <appender-ref ref="STDOUT" />
+    </logger>
 
     <logger name="com.parallax.server.blocklyprop.monitoring" level="info">
-        <appender-ref ref="file"/>
+        <appender-ref ref="FIX_WINDOW_BASED_FILE"/>
     </logger>
 
     <root level="info">
-        <appender-ref ref="file" />
+        <appender-ref ref="FIX_WINDOW_BASED_FILE" />
+<!--        <appender-ref ref="file" />   -->
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,14 +26,6 @@ Valid logging levels: TRACE, DEBUG, INFO, WARN and ERROR
         <appender-ref ref="file"/>
     </logger>
 
-    <logger name="com.parallax.server.blocklyprop" level="info">
-        <appender-ref ref="file"/>
-    </logger>
-
-    <logger name="com.parallax.server.blocklyprop.servelets" level="debug">
-        <appender-ref ref="file"/>
-    </logger>
-
     <root level="info">
         <appender-ref ref="file" />
     </root>


### PR DESCRIPTION
Reconfigure the log configuration to roll the log files over at 10MB and store no more than 20 archive files.