### PR TITLE
Remove debugging artifact from the pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
                 <configuration>
                     <files>
                         <!-- Location of the property file(s) -->
-                        <file>build-vars.properties</file>
+                        <file>build.properties</file>
                     </files>
                     <properties combine.self="append" />
                     <outputFile combine.self="append" />


### PR DESCRIPTION
Inadvertently left the properties file pointing to a test copy. This patch will correct the build process.
