### PR TITLE
1.1 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,13 @@
             <artifactId>logback-core</artifactId>
             <version>1.1.8</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+
         <!-- END Logging Dependencies -->
 
         <!-- Dependencies for Guice -->

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context antiJARLocking="true" path="/blockly"/>
+<Context antiResourceLocking="true" path="/blockly"/>


### PR DESCRIPTION
The production deployment will not start because something is requesting an old version of the logging library. We're not sure where that is coming from yet.