### PR TITLE
1.1 pre-deployment updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,22 @@
             <artifactId>logback-core</artifactId>
             <version>1.1.8</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
+
+        <!-- Fix for rouge LogManager call -->
+
+        <!-- Defined above - newer version -->
+        <!--
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.4</version>
+        </dependency>
+        -->
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.6.4</version>
         </dependency>
 
         <!-- END Logging Dependencies -->

--- a/src/main/java/com/parallax/server/blocklyprop/monitoring/Monitor.java
+++ b/src/main/java/com/parallax/server/blocklyprop/monitoring/Monitor.java
@@ -21,7 +21,7 @@ import java.net.InetSocketAddress;
 // import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
-import org.slf4j.LoggerFactory;
+//import org.slf4j.LoggerFactory;
 
 
 
@@ -102,13 +102,13 @@ public class Monitor {
     }
 
     private void initFileLogger() {
-                final Slf4jReporter reporter = Slf4jReporter
-                .forRegistry(metrics)
-                .outputTo(LoggerFactory.getLogger(Monitor.class))
-                .convertRatesTo(TimeUnit.SECONDS)
-                .convertDurationsTo(TimeUnit.MILLISECONDS)
-                .build();
-        reporter.start(graphiteReportingInterval, TimeUnit.SECONDS);
+//                final Slf4jReporter reporter = Slf4jReporter
+//                .forRegistry(metrics)
+//                .outputTo(LoggerFactory.getLogger(Monitor.class))
+//                .convertRatesTo(TimeUnit.SECONDS)
+//                .convertDurationsTo(TimeUnit.MILLISECONDS)
+//                .build();
+//        reporter.start(graphiteReportingInterval, TimeUnit.SECONDS);
 
     }
     

--- a/src/main/java/com/parallax/server/blocklyprop/utils/HelpFileInitializer.java
+++ b/src/main/java/com/parallax/server/blocklyprop/utils/HelpFileInitializer.java
@@ -70,12 +70,41 @@ public class HelpFileInitializer {
     }
 
     protected boolean checkSourceFilesPresent() {
+        // ------------------------------------------------------------------------------------
+        // Get the source help files from the location specified by the help.source setting
+        // in the application configuration file. If the setting is not supplied, use the
+        // default setting as specified in the constant DEFAULT_SOURCE_DIRECTORY
+        // ------------------------------------------------------------------------------------
         String sourceDirectory = configuration.getString("help.source", DEFAULT_SOURCE_DIRECTORY);
-        sourceDirectoryFile = new File(sourceDirectory);
-        System.out.println("Looking for help files in: " + sourceDirectoryFile.getAbsolutePath());
-        if (sourceDirectoryFile.exists() && sourceDirectoryFile.isDirectory()) {
-            return true;
+        System.out.println("Configuration file says help files are located at: " + sourceDirectory);
+
+        try {
+            System.out.println("Opening the source directory.");
+            sourceDirectoryFile = new File(sourceDirectory);
+
+            if (sourceDirectoryFile.exists()) {
+                System.out.println("The path: " + sourceDirectoryFile.getAbsolutePath() + " exists.");
+
+                if (sourceDirectoryFile.isDirectory()) {
+                    System.out.println("The path: " + sourceDirectoryFile.getAbsolutePath() + " is a directory.");
+                }
+
+            } else {
+                System.out.println("The path does not exist or permission is denied.");
+            }
+
+            if (sourceDirectoryFile.exists() && sourceDirectoryFile.isDirectory()) {
+                return true;
+            }
+
         }
+        catch (Exception ex) {
+            System.out.println("Error encounted while looking for help files.");
+            System.out.println("Error message is: " + ex.getMessage());
+        }
+
+
+
         sourceDirectoryFile = new File(new File(System.getProperty("user.home")), sourceDirectory);
         System.out.println("Looking for help files in: " + sourceDirectoryFile.getAbsolutePath());
         if (sourceDirectoryFile.exists() && sourceDirectoryFile.isDirectory()) {

--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -28,7 +28,7 @@ footer.clientdownloadlink = BlocklyProp-client
 # Application version numbers.
 application.major = 1
 application.minor = 1
-application.build = 446
+application.build = 447
 
 html.content_missing = Content missing
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -12,42 +12,32 @@ Valid logging levels: TRACE, DEBUG, INFO, WARN and ERROR
     <property name="APP_LOG_PATH" value="${catalina.home}/logs"/>
     <property name="APP_LOG_FILE_BASE" value="blockly-app"/>
 
-    <!--    
-    <appender name="file" class="ch.qos.logback.core.FileAppender">
-        <file>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}.log</file>
-        <encoder>
-            <pattern>%date %level [%file:%line] %msg%n</pattern>
-        </encoder>
-    </appender>
--->    
-    <appender name="FIX_WINDOW_BASED_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="RotateLogFiles" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-	    <fileNamePattern>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}%i.log</fileNamePattern>
-	    <minIndex>1</minIndex>
-	    <maxIndex>20</maxIndex>
-	</rollingPolicy>
+    	    <fileNamePattern>${APP_LOG_PATH}/${APP_LOG_FILE_BASE}%i.log</fileNamePattern>
+	        <minIndex>1</minIndex>
+	        <maxIndex>20</maxIndex>
+	    </rollingPolicy>
 
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>10MB</maxFileSize>
-	</triggeringPolicy>
+	    </triggeringPolicy>
      
-	<encoder>
+	    <encoder>
             <pattern>%date %level [%file:%line] %msg%n</pattern>
-	</encoder>
+	    </encoder>
     </appender>   
 
     <logger name="fixWindowBased" level="INFO">
-        <appender-ref ref="FIX_WINDOW_BASED_FILE" />
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="RotateLogFiles" />
     </logger>
 
     <logger name="com.parallax.server.blocklyprop.monitoring" level="info">
-        <appender-ref ref="FIX_WINDOW_BASED_FILE"/>
+        <appender-ref ref="RotateLogFiles"/>
     </logger>
 
     <root level="info">
-        <appender-ref ref="FIX_WINDOW_BASED_FILE" />
-<!--        <appender-ref ref="file" />   -->
+        <appender-ref ref="RotateLogFiles" />
     </root>
 </configuration>

--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -3,14 +3,13 @@
     Created on : 24-mei-2015, 18:41:02
     Author     : Michel
 --%>
-
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
 
-<!-- Support for experimental blocks in Demo builds  -->
-<!-- See developer notes to use this feature         -->
+<%-- Support for experimental blocks in Demo builds  --%>
+<%-- See developer notes to use this feature         --%>
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
-
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
Address an issue where the production servers were unable to start the blockly application because of a missing LogManager() class. This class is being referenced by at least one support package and cannot be updated immediately due to other dependencies. 

Correct the logic in the help system loader to allow the module to report details when the help system source files are inaccessible. 

Update logging configuration file to remove unused settings.

Increment the build number from 446 to 447.
