### PR TITLE
Backing off DOCTYPE commit.

### DIFF
--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -9,7 +9,7 @@
 <%-- Support for experimental blocks in Demo builds  --%>
 <%-- See developer notes to use this feature         --%>
 <c:set var="experimental" scope="page" value="${properties:experimentalmenu(false)}" />
-<!DOCTYPE html>
+<%-- <!DOCTYPE html> --%>
 <html>
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
Amazingly, this breaks a lot of code in the editor.