### PR TITLE
Replace home page help link with a refernece to the Learn web sites.

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -28,7 +28,7 @@ footer.clientdownloadlink = BlocklyProp-client
 # Application version numbers.
 application.major = 1
 application.minor = 1
-application.build = 447
+application.build = 448
 
 html.content_missing = Content missing
 

--- a/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
+++ b/src/main/webapp/WEB-INF/includes/pageparts/menu.jsp
@@ -58,7 +58,10 @@
                     </li>
                 </shiro:authenticated>
 
-                <li><a href="<url:getUrl url="/public/help"/>" target="_blank"><fmt:message key="menu.help" /></a></li>
+                <%-- Help link to the Learn reference section --%>
+                <%--  <li><a href="<url:getUrl url="/public/help"/>" target="_blank"><fmt:message key="menu.help" /></a></li> --%>
+                <li><a href="https://learn.parallax.com/ab-blocks" target="_blank"><fmt:message key="menu.help" /></a></li>
+
                 <%--
                 <li class="navbar-text">
                     <form style="margin-bottom: 0;">
@@ -73,7 +76,7 @@
         </div>
     </div>
     
-    <!-- Message of the Day goes here. -->
+    <%-- Message of the Day goes here. --%>
     <div class="container-fluid" style="background:#FAE6A4; color:#8a6d3b; padding:10px; display: none;" id="message-of-the-day">
         <div class="row">
             <div class="col-sm-12" align="center">


### PR DESCRIPTION
The internal help system has been a hot mess for some time now. This update replaces the link to the help system with a link to the Blockly resources located on the Learn site. The internal help system is deprecated and will be removed in a subsequent release.
