### PR TITLE
Issue #1638 - Update Help URI to point to help system hosted on learn

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/config/ServletsModule.java
+++ b/src/main/java/com/parallax/server/blocklyprop/config/ServletsModule.java
@@ -27,8 +27,6 @@ import com.parallax.server.blocklyprop.servlets.AuthenticationServlet;
 import com.parallax.server.blocklyprop.servlets.PrivacyPolicyServlet;
 import com.parallax.server.blocklyprop.servlets.ConfirmRequestServlet;
 import com.parallax.server.blocklyprop.servlets.ConfirmServlet;
-import com.parallax.server.blocklyprop.servlets.HelpSearchServlet;
-import com.parallax.server.blocklyprop.servlets.HelpServlet;
 import com.parallax.server.blocklyprop.servlets.NewOAuthUserServlet;
 import com.parallax.server.blocklyprop.servlets.OAuthGoogleServlet;
 import com.parallax.server.blocklyprop.servlets.PasswordResetRequestServlet;
@@ -130,9 +128,6 @@ public class ServletsModule extends ServletModule {
         serve("/public/clientinstructions").with(TextileClientInstructionsServlet.class);
         serve("/public/changelog").with(TextileChangeLogServlet.class);
 
-        // Help
-        serve("/public/help").with(HelpServlet.class);
-        serve("/public/helpsearch").with(HelpSearchServlet.class);
 
         // OAuth
         serve("/oauth/newuser").with(NewOAuthUserServlet.class);

--- a/src/main/java/com/parallax/server/blocklyprop/config/SetupConfig.java
+++ b/src/main/java/com/parallax/server/blocklyprop/config/SetupConfig.java
@@ -29,7 +29,6 @@ import com.google.inject.servlet.GuiceServletContextListener;
 import com.parallax.server.blocklyprop.SessionData;
 import com.parallax.server.blocklyprop.jsp.Properties;
 import com.parallax.server.blocklyprop.monitoring.Monitor;
-import com.parallax.server.blocklyprop.utils.HelpFileInitializer;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.util.Enumeration;
@@ -39,9 +38,6 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-// import java.sql.SQLException;
-// import ch.qos.logback.classic.LoggerContext;
 
 
 /**
@@ -73,7 +69,6 @@ public class SetupConfig extends GuiceServletContextListener {
                 bind(SessionData.class);
                 bind(Properties.class).asEagerSingleton();
 
-                bind(HelpFileInitializer.class).asEagerSingleton();
                 bind(Monitor.class).asEagerSingleton();
 
                 // Configure the backend data store

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/HelpSearchServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/HelpSearchServlet.java
@@ -33,7 +33,11 @@ import org.apache.lucene.store.FSDirectory;
 /**
  *
  * @author Michel
+ *
+ * @deprecated The help system has been moved to learn.parallax.com
+ *
  */
+@Deprecated
 @Singleton
 public class HelpSearchServlet extends HttpServlet {
 

--- a/src/main/java/com/parallax/server/blocklyprop/servlets/HelpServlet.java
+++ b/src/main/java/com/parallax/server/blocklyprop/servlets/HelpServlet.java
@@ -23,7 +23,10 @@ import org.apache.commons.configuration.Configuration;
 /**
  *
  * @author Michel
+ *
+ * @deprecated  Help system is now hosted on learn.parallax.com
  */
+@Deprecated
 @Singleton
 public class HelpServlet extends HttpServlet {
 

--- a/src/main/java/com/parallax/server/blocklyprop/utils/HelpFileInitializer.java
+++ b/src/main/java/com/parallax/server/blocklyprop/utils/HelpFileInitializer.java
@@ -37,7 +37,10 @@ import org.jsoup.nodes.Element;
 /**
  *
  * @author Michel
+ *
+ * @deprecated The help system has been moved to learn.parallax.com
  */
+@Deprecated
 @Singleton
 public class HelpFileInitializer {
 

--- a/src/main/webapp/editor/blocklyc.jsp
+++ b/src/main/webapp/editor/blocklyc.jsp
@@ -171,7 +171,7 @@
                                                     <li class="auth-true online-only" data-displayas="list-item"><a href="my/projects.jsp" class="url-prefix"><span class="keyed-lang-string" data-key="menu_my_projects"></span></a></li>
                                                     <li class="online-only"><a href="projects.jsp" class="url-prefix"><span class="keyed-lang-string" data-key="menu_community_projects"></span></a></li>
                                                     <hr class="online-only" style="line-height:5px; margin:5px;"/>
-                                                    <li><a href="public/help" target="_blank" class="url-prefix"><span class="keyed-lang-string" data-key="menu_help_reference"></span></a></li>
+                                                    <li><a href="https://learn.parallax.com/ab-blocks" target="_blank"><span class="keyed-lang-string" data-key="menu_help_reference"></span></a></li>
                                                     <hr style="line-height:5px; margin:5px;"/>
                                                     <li><a id="download-side" href="#" onclick="downloadPropC()"><span class="keyed-lang-string" data-key="menu_download_simpleide"></span></a></li>
                                                     <li><a id="download-project" href="#"><span class="keyed-lang-string" data-key="editor_download"></span></a></li>

--- a/src/main/webapp/my/projects.jsp
+++ b/src/main/webapp/my/projects.jsp
@@ -5,8 +5,7 @@
 --%>
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/includes/include.jsp"%>
-<!DOCTYPE html!>
-<html>
+<!DOCTYPE html>
     <head>
         <meta name="application-name" content="BlocklyProp"/>
         <meta name="msapplication-TileColor" content="#FFFFFF" />


### PR DESCRIPTION
#1638 The help link in the drop-down menu on the project editor page is currently pointing to a help system on the BP server that has been redirected to content on learn.parallax.com. 

This update corrects the anchor tag in the menu item to point to the help system located on the learn web site.
