### PR TITLE
Address corner use case on issue #1500

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/ProjectSharingDao.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/ProjectSharingDao.java
@@ -5,6 +5,7 @@
  */
 package com.parallax.server.blocklyprop.db.dao;
 
+import com.parallax.server.blocklyprop.db.generated.tables.ProjectSharing;
 import com.parallax.server.blocklyprop.db.generated.tables.records.ProjectSharingRecord;
 import java.util.List;
 
@@ -14,17 +15,64 @@ import java.util.List;
  */
 public interface ProjectSharingDao {
 
+    /**
+     * Retrieve a project
+     * @param idProject
+     * @param accessKey
+     * @return
+     */
     ProjectSharingRecord getProject(Long idProject, String accessKey);
 
+
+    /**
+     * Share an existing project
+     * @param idProject
+     * @param shareKey
+     * @return
+     */
     ProjectSharingRecord shareProject(Long idProject, String shareKey);
 
+
+    /**
+     * Disable the shared link to a project
+     * @param idProject
+     * @return
+     */
     int revokeSharing(Long idProject);
 
-    public List<ProjectSharingRecord> getSharingInfo(Long idProject);
+
+    /**
+     * Get a project sharing record
+     * @param idProject
+     * @return
+     */
+    List<ProjectSharingRecord> getSharingInfo(Long idProject);
     
     // Set the active flag in an existing shared project record
-    public ProjectSharingRecord activateProject(Long idProject);
+
+    /**
+     * Enable the project sharing link
+     *
+     * @param idProject
+     * @return
+     */
+    ProjectSharingRecord activateProject(Long idProject);
 
     // Remove a project sharing link record
-    public boolean deleteProjectSharingRecord(Long idProject);
+
+    /**
+     * Delete a project sharing record
+     *
+     * @param idProject
+     * @return
+     */
+    boolean deleteProjectSharingRecord(Long idProject);
+
+
+    /**
+     * Is the project sharing feature enabled for a project
+     * @param idProject
+     * @return
+     */
+    boolean isProjectSharingActive(Long idProject);
 }

--- a/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/db/dao/impl/ProjectSharingDaoImpl.java
@@ -7,9 +7,11 @@ package com.parallax.server.blocklyprop.db.dao.impl;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
 import com.parallax.server.blocklyprop.db.dao.ProjectSharingDao;
 import com.parallax.server.blocklyprop.db.generated.Tables;
 import com.parallax.server.blocklyprop.db.generated.tables.records.ProjectSharingRecord;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,7 +63,8 @@ public class ProjectSharingDaoImpl implements ProjectSharingDao {
 
     
     /**
-     * 
+     * Create a project sharing record
+     *
      * @param idProject
      * @param shareKey
      * @return 
@@ -176,6 +179,34 @@ public class ProjectSharingDaoImpl implements ProjectSharingDao {
                 .where(Tables.PROJECT_SHARING.ID_PROJECT.equal(idProject))
                 .execute() > 0;
 
+    }
+
+
+    /**
+     * Determine the on/off state of the project's shared link URL
+     *
+     * @param idProject
+     * @return
+     */
+    @Override
+    public boolean isProjectSharingActive(Long idProject) {
+
+        LOG.info("Retrieving sharing record for project {}", idProject);
+
+        ProjectSharingRecord project = create
+                .selectFrom(Tables.PROJECT_SHARING)
+                .where((Tables.PROJECT_SHARING.ID_PROJECT
+                        .equal(idProject)))
+                .fetchOne();
+
+        if (project == null) {
+            LOG.info("The sharing record for project {} was not found", idProject);
+            // Record not found
+            return false;
+        }
+
+        LOG.info("Project {} sharing is {}", idProject, project.getActive());
+        return project.getActive();
     }
 
 }

--- a/src/main/java/com/parallax/server/blocklyprop/rest/RestProject.java
+++ b/src/main/java/com/parallax/server/blocklyprop/rest/RestProject.java
@@ -145,7 +145,7 @@ public class RestProject {
         String endPoint = "REST:/rest/project/list/";
 
         LOG.info("{} Get request received", endPoint);
-        RestProjectUtils restProjectUtils = new RestProjectUtils();
+//        RestProjectUtils restProjectUtils = new RestProjectUtils();
 
         try {
             // Get the logged in user id for the current session
@@ -162,13 +162,13 @@ public class RestProject {
             //Sanity checks - is the request reasonable
 
             // Sort flag evaluation
-            if (!restProjectUtils.ValidateSortType(sort)) {
+            if (!RestProjectUtils.ValidateSortType(sort)) {
                 LOG.warn("{} Sort parameter failed. Defaulting to sort by project name", endPoint);
                 sort = TableSort.name;
             }
 
             // Sort order evaluation
-            if (!restProjectUtils.ValidateSortOrder(order)) {
+            if (!RestProjectUtils.ValidateSortOrder(order)) {
                 LOG.warn("{} Sort order parameter failed. Defaulting to ascending order", endPoint);
                 order = TableOrder.asc;
             }
@@ -343,12 +343,14 @@ public class RestProject {
             result.addProperty("success", true);
 
             return Response.ok(result.toString()).build();
-        } catch (AuthorizationException ae) {
+        }
+        catch (AuthorizationException ae) {
             LOG.warn("Project code not saved. Not Authorized");
             return Response.status(Response.Status.UNAUTHORIZED).build();
         }
         catch (Exception ex) {
             LOG.error("General exception encountered. Message is: ", ex.getMessage());
+            LOG.error("Error: {}", ex.getStackTrace().toString());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/com/parallax/server/blocklyprop/rest/RestSharedProject.java
+++ b/src/main/java/com/parallax/server/blocklyprop/rest/RestSharedProject.java
@@ -28,12 +28,14 @@ import com.cuubez.visualizer.annotation.Name;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
+
 import com.parallax.server.blocklyprop.TableOrder;
 import com.parallax.server.blocklyprop.TableSort;
 import com.parallax.server.blocklyprop.utils.RestProjectUtils;
 import com.parallax.server.blocklyprop.converter.ProjectConverter;
 import com.parallax.server.blocklyprop.db.generated.tables.records.ProjectRecord;
 import com.parallax.server.blocklyprop.services.ProjectService;
+
 import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -141,19 +143,18 @@ public class RestSharedProject {
             @QueryParam("limit") Integer limit, 
             @QueryParam("offset") Integer offset) {
 
-        RestProjectUtils restProjectUtils = new RestProjectUtils();
 
         String endPoint = "REST:/shared/project/list/";
         LOG.info("{} endpoint activated", endPoint);
 
         // Sort flag evaluation
-        if (!restProjectUtils.ValidateSortType(sort)) {
+        if (!RestProjectUtils.ValidateSortType(sort)) {
             LOG.warn("{} Sort parameter failed. Defaulting to sort by project name", endPoint);
             sort = TableSort.name;
         }
 
         // Sort order evaluation
-        if (!restProjectUtils.ValidateSortOrder(order)) {
+        if (!RestProjectUtils.ValidateSortOrder(order)) {
             LOG.warn("{} Sort order parameter failed. Defaulting to ascending order", endPoint);
             order = TableOrder.asc;
         }

--- a/src/main/java/com/parallax/server/blocklyprop/services/ProjectSharingService.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/ProjectSharingService.java
@@ -28,6 +28,9 @@ public interface ProjectSharingService {
     ProjectRecord getSharedProject(Long idProject, String shareKey);
 
     // Delete a project sharing record
-    public boolean deleteSharedProject(Long idProject);
+    boolean deleteSharedProject(Long idProject);
+
+    // Get current active state of a project share link
+    boolean isProjectShared(Long idProject);
     
 }

--- a/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
+++ b/src/main/java/com/parallax/server/blocklyprop/services/impl/ProjectSharingServiceImpl.java
@@ -32,16 +32,34 @@ public class ProjectSharingServiceImpl implements ProjectSharingService {
      */
     private static final Logger LOG = LoggerFactory.getLogger(ProjectSharingService.class);
 
-    private ProjectDao projectDao;
-    private ProjectSharingDao projectSharingDao;
 
-    // Inject dao connection to the project table
+    /**
+     *
+     */
+    private ProjectDao projectDao;
+
+
+    /**
+     * Inject dao connection to the project table
+     * @param projectDao
+     */
     @Inject
     public void setProjectDao(ProjectDao projectDao) {
         this.projectDao = projectDao;
     }
 
-    // Inject connection to the project_sharing table
+
+    /**
+     *
+     */
+    private ProjectSharingDao projectSharingDao;
+
+
+    /**
+     * Inject connection to the project_sharing table
+     *
+     * @param projectSharingDao
+     */
     @Inject
     public void setProjectSharingDao(ProjectSharingDao projectSharingDao) {
         this.projectSharingDao = projectSharingDao;
@@ -153,5 +171,17 @@ public class ProjectSharingServiceImpl implements ProjectSharingService {
     public boolean deleteSharedProject(Long idProject) {
         LOG.info("Deleting project share link for project {}", idProject);
         return projectSharingDao.deleteProjectSharingRecord(idProject);
+    }
+
+
+    /**
+     *
+     * @param idProject
+     * @return
+     */
+    @Override
+    public boolean isProjectShared(Long idProject) {
+        LOG.info("Evaluating project {} sharing status.", idProject);
+        return projectSharingDao.isProjectSharingActive(idProject);
     }
 }

--- a/src/main/java/com/parallax/server/blocklyprop/utils/RestProjectUtils.java
+++ b/src/main/java/com/parallax/server/blocklyprop/utils/RestProjectUtils.java
@@ -33,7 +33,7 @@ public class RestProjectUtils {
      * @return
      * Return true if the provided sort is a valid item, otherwise return false
      */
-    public boolean ValidateSortType(TableSort sort) {
+    public static boolean ValidateSortType(TableSort sort) {
 
         if (sort != null) {
             for (TableSort t : TableSort.values()) {
@@ -46,7 +46,7 @@ public class RestProjectUtils {
         return false;
     }
 
-    public boolean ValidateSortOrder(TableOrder order) {
+    public static boolean ValidateSortOrder(TableOrder order) {
 
         boolean parametersValid = false;
 

--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -28,7 +28,7 @@ footer.clientdownloadlink = BlocklyProp-client
 # Application version numbers.
 application.major = 1
 application.minor = 1
-application.build = 453
+application.build = 455
 
 html.content_missing = Content missing
 


### PR DESCRIPTION
This update corrects a corner use case where a currently logged in user is viewing a private project that is accessed through a Shared Project link and the currently logged in use attempt to save the project into their own library. 

The expected behavior was for the server to create a new, private, unshared project in the currently logged in user's library. Instead, the Save and Save-As functions would silently fail and leave the user in the original private shared project. No new project was created. 