### PR TITLE
Correct Issue 1658

### DIFF
--- a/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
+++ b/src/main/resources/com/parallax/server/blocklyprop/internationalization/translations.properties
@@ -28,7 +28,7 @@ footer.clientdownloadlink = BlocklyProp-client
 # Application version numbers.
 application.major = 1
 application.minor = 1
-application.build = 456
+application.build = 457
 
 html.content_missing = Content missing
 


### PR DESCRIPTION
Corrects issue #1658. A NullPointerException can occur through a rare but possible chain of events. 

When a request is set to the Cloud Session server and the Cloud Session server is unable to contact the back end database, the Cloud Session server returns an empty user object, which is not a expected result in the BlocklyProp code.

Ultimately, the root cause will need to be addressed in the Cloud Server. This patch will operate as a defensive measure until that occurs.