### PR TITLE
Correct Javascript declarations and add support for library metadata.

### DIFF
--- a/src/main/java/com/parallax/server/blocklyprop/rest/RestCompile.java
+++ b/src/main/java/com/parallax/server/blocklyprop/rest/RestCompile.java
@@ -18,27 +18,17 @@ import com.parallax.client.cloudcompiler.objects.CompilationException;
 import com.parallax.client.cloudcompiler.objects.CompilationResult;
 import com.parallax.client.cloudcompiler.objects.CompileAction;
 import com.parallax.client.cloudsession.CloudSessionBucketService;
-import com.parallax.client.cloudsession.exceptions.EmailNotConfirmedException;
-import com.parallax.client.cloudsession.exceptions.InsufficientBucketTokensException;
-import com.parallax.client.cloudsession.exceptions.ServerException;
-import com.parallax.client.cloudsession.exceptions.UnknownBucketTypeException;
-import com.parallax.client.cloudsession.exceptions.UnknownUserIdException;
-import com.parallax.client.cloudsession.exceptions.UserBlockedException;
+import com.parallax.client.cloudsession.exceptions.*;
 import com.parallax.server.blocklyprop.rest.typewrappers.CompileActionTypeWrapper;
 import com.parallax.server.blocklyprop.services.impl.SecurityServiceImpl;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 /**
  *
@@ -72,11 +62,20 @@ public class RestCompile {
     @Name("compile")
     @Produces("text/plain")
     public Response get(@QueryParam("test") String testString) {
-        
         LOG.info("REST:/rest/compile/ Get request received");
-
         return Response.ok("Hello " + testString).build();
     }
+
+    @GET
+    @Detail("Get Simple Libraries version")
+    @Name("version")
+    @Produces("text/plain")
+    public Response version() {
+        LOG.info("REST:/rest/compile/ Get request received");
+        return Response.ok("v0.0.0").build();
+    }
+
+
 
     @POST
     @Path("/spin/{action}")

--- a/src/main/webapp/WEB-INF/servlet/index.jsp
+++ b/src/main/webapp/WEB-INF/servlet/index.jsp
@@ -46,9 +46,9 @@
         <link rel="stylesheet" href="<url:getCdnUrl url="/lib/bootstrap/core/css/bootstrap.min.css"/>" />
         <link rel="stylesheet" href="<url:getCdnUrl url="/lib/bootstrap/plugins/bootstrap-table.min.css"/>" />
         <title>BlocklyProp</title>
-        <script src="<url:getCdnUrl url="/lib/jquery-1.11.3.min.js"/>" ></script>
-        <script src="<url:getCdnUrl url="/lib/bootstrap/core/js/bootstrap.min.js"/>"></script>
-        <script src="<url:getCdnUrl url="/authenticate.js"/>" ></script>
+        <script type="application/javascript" src="<url:getCdnUrl url="/lib/jquery-1.11.3.min.js"/>" ></script>
+        <script type="application/javascript" src="<url:getCdnUrl url="/lib/bootstrap/core/js/bootstrap.min.js"/>"></script>
+        <script type="application/javascript" src="<url:getCdnUrl url="/authenticate.js"/>"></script>
     </head>
     <body>
         <%@ include file="/WEB-INF/includes/pageparts/menu.jsp"%>
@@ -78,7 +78,7 @@
         </script>
 
         <%@ include file="/WEB-INF/includes/pageparts/project-login-dialog.jsp"%>
-        <script src="<url:getCdnUrl url="/latest.js"/>" ></script>
+        <script type="application/javascript" src="<url:getCdnUrl url="/latest.js"/>" ></script>
 
         <%@ include file="/WEB-INF/includes/pageparts/footer.jsp"%>
     </body>


### PR DESCRIPTION
Add MIME type to some JavaScript declarations where it was omitted. Without them, the browser may interpret the content as a plain text stream.

Add support for obtaining metadata from the compiler server to indicate the version of the library in use by the compiler. This data can be used to help the UI ensure that the back-end libraries can support the blocks available in the UI. 